### PR TITLE
feat: enable Pickup V2 batch pickup via env flag

### DIFF
--- a/app/.env.sample
+++ b/app/.env.sample
@@ -1,6 +1,8 @@
 # OCA_URL sourced from upstream bcgov/aries-oca-bundles repository
 OCA_URL=https://raw.githubusercontent.com/bcgov/aries-oca-bundles/main/
 MEDIATOR_URL=https://f326-207-194-65-204.ngrok.io?c_i=eyJAdHlwZSI6ICJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMC9pbnZpdGF0aW9uIiwgIkBpZCI6ICI2MjQ0ZThiNS0wNWYzLTRhYWItYjM1Yy1lYWVlMWNmZTAyM2MiLCAicmVjaXBpZW50S2V5cyI6IFsiQ3lqM1BHRUJzQ3RyUGFtTTQyRngza3BlYmR2QWdNd1lGejlFS3RmNnlUN3giXSwgImxhYmVsIjogIk1lZGlhdG9yIiwgInNlcnZpY2VFbmRwb2ludCI6ICJodHRwczovL2YzMjYtMjA3LTE5NC02NS0yMDQubmdyb2suaW8ifQ==
+# Enable Pickup V2 live mode + batch pickup (required for Credo-TS mediators)
+MEDIATOR_USE_V2_BATCH_PICKUP=false
 MEDIATOR_USE_PUSH_NOTIFICATIONS=false
 LOAD_STORYBOOK=false
 PROOF_TEMPLATE_URL=

--- a/app/src/hooks/useBCAgentSetup.ts
+++ b/app/src/hooks/useBCAgentSetup.ts
@@ -34,10 +34,9 @@ const loadCachedLedgers = async (): Promise<IndyVdrPoolConfig[] | undefined> => 
   }
 }
 
-const checkMediatorType = async (agent: Agent, mediatorUrl: string): Promise<void> => {
-  if (mediatorUrl.startsWith('https://mediator-credo-dev.apps.silver.devops.gov.bc.ca/')) {
+const configureMessagePickup = async (agent: Agent): Promise<void> => {
+  if (Config.MEDIATOR_USE_V2_BATCH_PICKUP === 'true') {
     await agent.mediationRecipient.initiateMessagePickup(undefined, MediatorPickupStrategy.PickUpV2LiveMode)
-  } else {
     batchPickup(agent)
   }
 }
@@ -198,7 +197,7 @@ const useBCAgentSetup = () => {
         const restartedAgent = await restartExistingAgent(agentInstanceRef.current, walletSecret)
         if (restartedAgent) {
           logger.info('Successfully restarted existing agent...')
-          await checkMediatorType(restartedAgent, mediatorUrl)
+          await configureMessagePickup(restartedAgent)
           periodicPickupCleanupRef.current?.()
           periodicPickupCleanupRef.current = startPeriodicTrustPing(restartedAgent, PERIODIC_PICKUP_INTERVAL_MS)
           refreshAttestationMonitor(restartedAgent)
@@ -221,8 +220,8 @@ const useBCAgentSetup = () => {
       logger.info('Initializing agent...')
       await newAgent.initialize()
 
-      logger.info(`checking mediator type for ${mediatorUrl}`)
-      await checkMediatorType(newAgent, mediatorUrl)
+      logger.info(`configuring message pickup for ${mediatorUrl}`)
+      await configureMessagePickup(newAgent)
       periodicPickupCleanupRef.current?.()
       periodicPickupCleanupRef.current = startPeriodicTrustPing(newAgent, PERIODIC_PICKUP_INTERVAL_MS)
 


### PR DESCRIPTION
## Summary

- Replace hardcoded BC Gov mediator URL check with `MEDIATOR_USE_V2_BATCH_PICKUP` env flag
- When `true`, agent startup initiates Pickup V2 live mode + batch pickup (required for Credo-TS mediators)
- When `false`/unset, no special startup pickup — avoids wrong strategy for legacy acapy mediators
- Document flag in `app/.env.sample` (defaults to `false`; prod URL stays in env config only)

Closes #4

## Context

Dropped connections and missed offline messages were traced to implicit/V1 pickup against mediators that don't handle batch delivery well. Credo-TS mediators need explicit V2 + batch pickup. This keeps the wallet code mediator-agnostic: set `MEDIATOR_URL` + flip the flag when pointing at Credo.

Prod cutover (set staging/prod `MEDIATOR_URL`, enable flag, smoke tests) tracked in #5.

## Test plan

- [x] Local dev: `MEDIATOR_USE_V2_BATCH_PICKUP=true` + Credo mediator → V2 live mode + batch pickup in logs
- [x] Offline basic messages recovered on wallet reopen (3 queued messages)
- [x] Offline VRC/credential exchange recovered on wallet reopen (full protocol + attestation)
- [ ] CI passes
- [ ] Reviewer: flag unset → no V2 pickup initiated on startup
