### PR TITLE
docs(plans): packaging Keyring as a reference app + SDK — working notes

### DIFF
--- a/docs/plans/reference-app-sdk-packaging.md
+++ b/docs/plans/reference-app-sdk-packaging.md
@@ -6,6 +6,12 @@
 
 **Positioned as a sibling to the openvtc plan, not a subtask of it** — same relationship `locality-plan.md` has (openvtc-integration-plan.md §4.6: "the locality axis now has its own plan"). It depends on that plan's infra (Trust Tasks, witness recast, PNM/VTA) but its own scope — developer packaging, DI/theming ergonomics, a trading-card demo — extends past Trust Tasks into territory the parent plan doesn't own. It stays a standalone exploratory doc rather than moving under `openvtc-integration-plan/` because subtasks there state *current design* in present tense (per `docs/plans/CLAUDE.md`); this is still pre-decision brainstorming.
 
+**Review index.** Companions carrying the reasoning behind the positions below:
+
+| Companion | Author | What it settles |
+|---|---|---|
+| [`2026-09-01-al.md`](./reference-app-sdk-packaging/2026-09-01-al.md) | AL | SDK scope and framing (mobile-first, SDK as the deliverable); consume upstream Trust Tasks rather than reimplement, and the duplicate-implementation problem it exposes; wrap orchestration rather than types; the VTA Farm as first-class onboarding; `ref-08-pnm-core-hermes` as the unblocking experiment; requirements R6–R12 |
+
 **Reconciled against `openvtc-integration-plan.md` §6 ("Demo concepts — brainstorm only")**, which already proposes several of the same demos under different names, with more ecosystem grounding (real Trust Task type URIs, a stated flagship target). This file's per-idea notes below cite the overlap explicitly rather than treating these as independent proposals:
 
 | This file's idea | §6 prior art |
@@ -168,3 +174,77 @@ Cutting across all ten ideas, five infra pieces keep recurring, ranked by how ma
 - Every new use case that isn't pure UI needs its own Trust Task type spec (`payload.schema.json` per `trust_tasks_subtask.md` §1, point 4) — and per that same document, publishing under a private authority we control is fully conforming (§6.5), so none of these demos need to wait on `trusttasks.org` registry work to exist.
 
 **Sequencing implication:** items 1 and 4 above are the cheapest and unlock the most (Approver, Multi-Factor, HFA, trading-card, and a stubbed Agent-Leash all become buildable). Item 3 (quorum) is next — it's genuinely new orchestration but no new protocol. Items 2 and 5 are each a bounded, mostly-mechanical decoupling of infra that already works. Recovery (#6) and the agent-identity half of #5 are the only two ideas that need real new design work beyond assembly of existing pieces — consistent with the user's own "biggest swing" / "bigger swing" framing for both.
+
+---
+
+## Adopted positions — 2026-09-01
+
+Recorded here because the plan holds current design; the argument and the
+evidence for each of these is in
+[`2026-09-01-al.md`](./reference-app-sdk-packaging/2026-09-01-al.md), which
+should be read before revisiting any of them.
+
+**Framing.** Mobile-first, and the SDK is the deliverable — the reference app is
+what proves it. The notes above are a reference-app packaging analysis and stay
+valid as such; the SDK half is stated in the companion and adds requirements
+R6–R12 (versioning and publishing, package inventory, error taxonomy, a VTC
+administration reference app, documentation in multiple languages, a
+compatibility matrix, supply-chain posture).
+
+**Trust Tasks: consume upstream, own the orchestration.**
+`@openvtc/trust-tasks` is generated bindings for the whole registry plus a
+zero-dependency runtime, and it *injects* cryptography rather than implementing
+it (`proofPolicy`, `payloadPolicy`). We adopt its types and machinery and own
+what it deliberately leaves blank — a concrete `eddsa-jcs-2022` signer and
+verifier including hardware-backed signing, a payload validator, and the
+binding-0.2 DIDComm carriage.
+
+**A duplicate implementation exists today and has to go.**
+`@bifold/trust-tasks` does not depend on the upstream package at all; it is a
+parallel implementation over `canonicalize` + `ajv`. Since `pnm-core` depends on
+`@openvtc/trust-tasks`, bringing PNM into the wallet would ship two Trust Tasks
+implementations — two JCS canonicalizers — in one bundle, whose failure mode is
+an intermittent per-document signature mismatch rather than a build error. The
+companion sequences the remediation **T0–T4**; T0 (advance the pins) and T1
+(measure whether the two canonicalizers actually diverge, before changing any
+code) are independent of everything else here and should proceed regardless.
+
+**The package splits on two axes, not one.** Platform-neutral is not enough:
+`@bifold/trust-tasks` depends on Credo, so a relying party embedding the SDK to
+request an approval would be made to install an agent framework. A Credo-free
+**pure layer** (documents, proofs, digests) is shared by the wallet, the
+witness-server, the VTA and any relying-party service; a **Credo adapter**
+(askar keys, DIDComm carriage) is wallet-and-witness only. There is no separate
+"Trust Tasks backend" to build — there are services that embed the pure layer.
+
+**R5 is restated.** An open `typeUri` → handler registry is necessary but not
+sufficient. Registration carries `{ spec, orchestration, renderer }`, because
+the framework is document-level and says nothing about what `ceremony.ts`
+already does: proposer selection (`isDeterministicProposer`), peer capability
+discovery (`peerSupportsTaskType`), version gating
+(`TRUST_TASKS_MIN_RCE_VERSION`), idempotence on redelivery (documents queried by
+`{typeUri, connectionId}`), and the `vrcFlowStore` interlock. That orchestration
+— a session over a relationship — is the SDK's product surface, and it is the
+reason wrapping is worth doing at all.
+
+**R1 becomes the VTA Farm.** Upstream's own guidance is Path A (the managed
+Farm: VTA hosting, DID hosting, mediator connection management, no server and no
+public domain) for newcomers, with self-hosting as Path B where
+`tsp-reference/ref-05-local-vta` is the precedent. Open question that gates the
+Agent Leash: Path A's prerequisites are a Farm account, passkey support and
+locally installed PNM software — i.e. the browser plugin — so whether a React
+Native wallet can authenticate to a Farm-hosted VTA is unanswered.
+
+**The critical-path experiment is `ref-08-pnm-core-hermes`.**
+`@openvtc/pnm-core` carries a complete TypeScript VTA client under `src/vta/`
+on an RN-viable dependency stack (noble, scure, cfworker/json-schema, cbor-x)
+that is nonetheless described as browser-side and mentions neither React Native
+nor Hermes anywhere. Proving it under Hermes answers three questions this plan
+is currently guessing at: whether Keyring can talk to a Farm VTA, whether the
+Agent Leash is a port or a rewrite, and whether the SDK owns a VTA client or
+consumes one.
+
+**Out of scope here.** Prague (which connects Keyring directly to the Farm and
+is parallel, not downstream); OCA in the SDK core (confirmed absent from the
+Trust Task path — it stays in the reference app for credential-shaped demos); a
+full UI kit (`keyring-theme/` plus two screens is version zero).

--- a/docs/plans/reference-app-sdk-packaging.md
+++ b/docs/plans/reference-app-sdk-packaging.md
@@ -219,15 +219,19 @@ what it deliberately leaves blank — a concrete `eddsa-jcs-2022` signer and
 verifier including hardware-backed signing, a payload validator, and the
 binding-0.2 DIDComm carriage.
 
-**A duplicate implementation exists today and has to go.**
-`@bifold/trust-tasks` does not depend on the upstream package at all; it is a
-parallel implementation over `canonicalize` + `ajv`. Since `pnm-core` depends on
-`@openvtc/trust-tasks`, bringing PNM into the wallet would ship two Trust Tasks
-implementations — two JCS canonicalizers — in one bundle, whose failure mode is
-an intermittent per-document signature mismatch rather than a build error. The
-companion sequences the remediation **T0–T4**; T0 (advance the pins) and T1
-(measure whether the two canonicalizers actually diverge, before changing any
-code) are independent of everything else here and should proceed regardless.
+**Two JCS canonicalizers are already in the bundle, and nothing measures
+them.** We do consume upstream — `@openvtc/trust-tasks` is a declared dependency
+of `@bifold/core` and `@bifold/witness-server` at `^0.9.0`. What is duplicated
+is the canonicalization: our `documentProof.ts` uses the `canonicalize` package
+while upstream's runtime implements RFC 8785 itself, and both ship today. If
+they disagree on any input, a digest computed by one path fails against the
+other — intermittently, per document, with no build error. Separately we are
+pinned `^0.9.0` against **0.16.8**, spanning framework 0.5.0 (the two named
+digests, the lifecycle table, the freshness rules), and `pnm-core` will require
+a newer one, so Prague forces the bump. The companion sequences remediation
+**T0–T4**; **T1 — measure whether the two canonicalizers actually diverge,
+before changing any code — is the cheapest step and applies to the bundle as it
+stands**, independent of any packaging decision.
 
 **The package splits on two axes, not one.** Platform-neutral is not enough:
 `@bifold/trust-tasks` depends on Credo, so a relying party embedding the SDK to

--- a/docs/plans/reference-app-sdk-packaging.md
+++ b/docs/plans/reference-app-sdk-packaging.md
@@ -187,9 +187,29 @@ should be read before revisiting any of them.
 **Framing.** Mobile-first, and the SDK is the deliverable — the reference app is
 what proves it. The notes above are a reference-app packaging analysis and stay
 valid as such; the SDK half is stated in the companion and adds requirements
-R6–R12 (versioning and publishing, package inventory, error taxonomy, a VTC
-administration reference app, documentation in multiple languages, a
-compatibility matrix, supply-chain posture).
+**R6–R17**: versioning and publishing; the package inventory with dependency
+direction drawn before extraction; an error taxonomy as a product surface; a VTC
+administration reference app (Wikimedia Foundation as the named client);
+documentation in multiple languages; a compatibility matrix; supply-chain
+posture; a documentation stack, stable hosted address and agent-readable
+index; SDK conventions borrowed from mature SDKs — of which a **sandbox makes R1
+table stakes rather than polish**; an intake channel for builders; a showcase
+surface kept separate from the docs; and a multi-language strategy built on
+**published conformance vectors** rather than OpenAPI generators, which cannot
+carry the canonicalization and signature verification that make a response
+checkable.
+
+Two acceptance criteria are stated so they can fail: the reference app consumes
+the **published** SDK rather than the source, and "stupid easy" is a timed
+walkthrough by someone who has not seen the repo, not an assertion.
+
+Three upstream overlaps to check before building anything: `@openvtc/rp-sdk`
+(the relying-party surface), `@openvtc/pnm-core` (the passkeys-to-VTA bridge,
+which is substantially the slate's passkey product), and `vtc-service`'s
+existing administrative routes. Two risks in the product slate are recorded in
+the companion — an identity model that conflicts with the correlation-scope
+position we argued upstream this week, and three "ready to build" items whose
+infrastructure is not in this repo.
 
 **Trust Tasks: consume upstream, own the orchestration.**
 `@openvtc/trust-tasks` is generated bindings for the whole registry plus a

--- a/docs/plans/reference-app-sdk-packaging.md
+++ b/docs/plans/reference-app-sdk-packaging.md
@@ -1,0 +1,170 @@
+# Packaging Keyring as a Reference App + SDK — Working Notes
+
+**Status:** Exploratory notes, not a commitment to implement. Not yet reviewed against `docs/plans/CLAUDE.md`'s companion structure — this is a single working draft, to be split into a proper plan + dated companions once a direction is chosen.
+**Scope:** whether/how to repackage this repo so prospective developers can stand up small demo apps for distinct identity/credential use cases, each backed by the same underlying Keyring/Credo/VRC/Trust-Task infra.
+**Related:** [`openvtc-integration-plan.md`](./openvtc-integration-plan.md) (Trust Tasks, TSP transport), its [`trust_tasks_subtask.md`](./openvtc-integration-plan/trust_tasks_subtask.md) (Trust Task message shape, witness recast) and [`pnm_cnm_subtask.md`](./openvtc-integration-plan/pnm_cnm_subtask.md) (PNM/VTA client, "the phone as approver"), and [`../HARDWARE_ATTESTATION_FLOW.md`](../HARDWARE_ATTESTATION_FLOW.md) (hardware signing).
+
+**Positioned as a sibling to the openvtc plan, not a subtask of it** — same relationship `locality-plan.md` has (openvtc-integration-plan.md §4.6: "the locality axis now has its own plan"). It depends on that plan's infra (Trust Tasks, witness recast, PNM/VTA) but its own scope — developer packaging, DI/theming ergonomics, a trading-card demo — extends past Trust Tasks into territory the parent plan doesn't own. It stays a standalone exploratory doc rather than moving under `openvtc-integration-plan/` because subtasks there state *current design* in present tense (per `docs/plans/CLAUDE.md`); this is still pre-decision brainstorming.
+
+**Reconciled against `openvtc-integration-plan.md` §6 ("Demo concepts — brainstorm only")**, which already proposes several of the same demos under different names, with more ecosystem grounding (real Trust Task type URIs, a stated flagship target). This file's per-idea notes below cite the overlap explicitly rather than treating these as independent proposals:
+
+| This file's idea | §6 prior art |
+|---|---|
+| The Agent Leash | "Meet your Agent" — LLM beside the VTA, its own scoped-DID identity, phone holds `approve`; "a prompt-injected agent is rejected/escalated identically — security never depends on the model behaving" |
+| The Approver / Passkeys | "Log in with your Agent" + one-veto ACL grant demo (P1 MVP); vignettes: subscription killer (`vault/proxy-login`, each login phone-approved), temporary family access (`acl/grant` + `expiresAt`) |
+| Human Factor Authentication | Vignette: "AI-written commits signed only after phone approval" (VGI `did-git-sign`) — a human confirms an agent's action, the same shape as HFA |
+| Prove You're Human, or an Honest Agent | Vignette: "verified-human interaction (PHC personhood without identity disclosure)" — human half only; no §6 prior art for the "honest agent" half |
+| The Quorum, Recovery, Invite-Nobody-Can-Forward, Trading cards | No §6 prior art — genuinely new to this file |
+
+**Correction to this file's original research (2026-08-31):** the first draft characterized "a generic Trust Task inbox/approve-deny surface" as not existing anywhere, based on reading `bifold/packages/trust-tasks` (platform-neutral wire plumbing) and the legacy `vrc-manager.ts`/`witnessed-vrc-manager.ts`. It missed `bifold/packages/core/src/modules/trust-tasks/` — the app-level recast module current work on `feat/trust-tasks-integration` is actively building (files touched as recently as today). That module's `TrustTasksService.consume()` already takes an arbitrary `TrustTaskSpecPolicy` (any `typeUri`) and handler callback, running it through real §7.2 schema validation, proof policy and identity cross-check, with generic `respondWith`/`refuse` replies — a genuine, VRC-agnostic consume/respond engine, not a VRC-specific one. What's *not* generic yet: `setupTrustTasksInbound` in `ceremony.ts` dispatches on `document.type` via a closed if/else chain (one branch per known VRC/witness/discovery type), each branch calling a bespoke business-logic handler — not an open registry — and there is no UI anywhere that renders an arbitrary incoming Trust Task and lets a person approve/deny it; the existing handlers respond automatically per-protocol. So the "Approver" gap is real but narrower than first stated: it's an open type→handler registry plus a UI render/approve-deny layer sitting *on top of* an engine that already exists, not a new engine. Item 1 below and the Patterns section are corrected accordingly.
+
+---
+
+## Checklist
+
+One row per proposed demo. Status is about **infra that exists in this repo today**, not about idea quality.
+
+| # | Idea | Status | Blocking gap |
+|---|---|---|---|
+| 1 | The Approver | 🧩 partial (engine exists) | The consume/respond engine (`TrustTasksService.consume()`) is already generic; the gap is an open type→handler registry (today a closed if/else in `ceremony.ts`) plus a UI render/approve-deny layer, neither of which exists for arbitrary task types |
+| 2 | Passkeys Nobody Has to Store | 🧩 partial | Hardware signing is real and tested, but wired only inside VRC issuance, not exposed standalone |
+| 3 | More Factors, Fewer Taps | 🧩 rides on #1 | Same gap as #1 (registry + UI, not the engine); evidence already supports multiple factor types |
+| 4 | The Agent Leash | ⛔ greenfield in this repo | No PNM/VTA client exists here at all (it's a Rust ecosystem plan, not ported) |
+| 5 | Prove You're Human, or an Honest Agent | 🧩 half-partial | "Human" half rides `verifier` + OCA; "honest agent" half needs a new credential type |
+| 6 | Recovery From People, Not Your Inbox | ⛔ greenfield | No social-recovery or multi-party vouching code anywhere in the repo |
+| 7 | An Invite Nobody Can Forward | ⛔ blocked externally | Anti-forwarding depends on VTC roster/membership infra outside this repo's control |
+| 8 | The Quorum | ⛔ no code, but composable | Witness protocol is single-witness only; would be orchestration on top of existing primitives, not new wire protocol |
+| 9 | Human Factor Authentication | 🧩 partial | Rides #1's gap + Trust Task `exposure` field (framework 0.3+), not yet used for redaction in UI. §6 vignette: "AI-written commits signed only after phone approval" |
+| — | Trading-card exchange | ✅ mostly ready | Skins existing RCard exchange + OCA display registry; smallest new-code footprint of anything on this list |
+
+Legend: ✅ ready today · 🧩 partial (real primitives exist, assembly/decoupling needed) · ⛔ greenfield or externally blocked.
+
+---
+
+## The developer path, treated as a requirement
+
+Rather than starting from "what infra is missing" and hoping the result is easy to package, this section walks the actual path a developer takes trying one use case for themselves, and derives requirements from the friction that walkthrough finds. The **Patterns and core requirements** section further down (the "what to build" infra list) exists to satisfy the requirements found here — read this section first.
+
+### Generic template — every use case shares steps 1–3, diverges from step 4
+
+1. **Clone + install.** `yarn install` at repo root (runs `ensure-bifold-ready` as preinstall — inits/builds the bifold submodule). Identical for every use case.
+2. **Stand up a mediator.** Copy `app/.env.sample` → `app/.env`. `MEDIATOR_URL` must be a live, reachable DIDComm mediator carrying an embedded connection invitation — the checked-in sample value is one specific ngrok tunnel + invitation from whenever it was captured, not a working default for a new developer. Nothing in the app boots usefully without this, regardless of use case.
+3. **Build and run.** `yarn ios:setup && yarn ios` or `yarn android` — one native scheme (`AriesBifold`), no per-demo build flavor. "Try use case X" and "run Keyring itself" are the same build target today.
+4. **Skin the app.** Copy `app/src/keyring-theme/` to your own theme directory and edit the plain-TS color/logo/copy objects — no config file, no build step, but it's a file to duplicate and prune, not fill in.
+5. **Wire behavior via DI.** Copy `app/container-imp.ts`'s pattern (a child container re-registering `container-api.ts` tokens). The only worked example is 418 lines mixing generic override plumbing with Keyring's own product logic (RCard help text, ledger config, notification wiring, onboarding steps) — a developer has to read the whole thing to find the handful of lines that show *how to override one token*.
+6. **Register the use-case-specific content** — a credential type + OCA bundle for something credential-shaped like trading cards; a Trust Task type + payload spec + renderer for anything Approver-shaped, once the registry in requirement R5 below exists.
+7. **Exchange / demo it** — two devices, QR/OOB invite, riding whatever protocol the use case needs (VRC exchange today, for anything credential-shaped).
+
+### Concrete walkthrough — trading cards (the one idea that's ✅ ready today, so steps 6–7 need no new engine work)
+
+- **6a. Credential shape.** Extend RCard's `jCard` shape (`bifold/packages/core/src/modules/vrc/types/rcard.ts`) with an avatar/image field (data URI or URL) — this is the "hook for a developer to determine how to make their trading card" the original ask described.
+- **6b. Skin the card.** `TOKENS.UTIL_OCA_RESOLVER` is DI-injected (`app/container-imp.ts:286-291`) as `new RemoteOCABundleResolver(Config.OCA_URL, ...)`. `OCA_URL` in the checked-in `.env.sample` defaults to `bcgov/aries-oca-bundles`'s raw-GitHub tree, so adding a branding overlay for a new credential type means adding JSON files to a git-hosted directory — fork that repo, or host your own raw-JSON tree on GitHub, and point `OCA_URL` at it. No server to run, but it does need a public URL: nothing wires up a "read the bundle straight from a file bundled with the app" resolver today, even though the interface is small enough that one would be (`resolve(params): Promise<OCABundle | undefined>`, `bifold/packages/oca/src/legacy/resolver/oca.ts`).
+- **6c. Custom rendering**, only if the branding overlay alone isn't expressive enough for a genuinely trading-card-shaped layout: register through the existing credential-display registry (`ICredentialDisplayRegistry`, `map-to-card.ts`, `CredentialCard10.tsx`/`Card11Pure.tsx`).
+- **7. Exchange.** Ride the existing RCard/VRC exchange (`RCardOnboarding.tsx`, `rCardCredential.ts`) unchanged.
+
+What this shows: for the one demo needing zero missing engine work, getting a PoC running is still realistically a day or two for someone unfamiliar with the codebase — not because a primitive is missing, but because of copy-and-prune friction at steps 2, 5 and 6b. That's a packaging problem, fixable without touching any protocol code, not a build-more-infra problem.
+
+### Requirements this puts on the packaging plan
+
+- **R1 — a documented, one-command local stack** (mediator, and eventually a local VTA/witness). Checked concretely: the only local-infra spin-up precedent in the repo is for the *witness*, not the mediator — `e2e/lib/witness.js` spawns `bifold/packages/witness-server` locally, opens a `cloudflared` tunnel for HTTPS, and injects the resulting invitation, fully scripted behind one function call. Nothing equivalent exists for the DIDComm mediator itself: `app/.env.sample`'s `MEDIATOR_URL` is a single captured invitation from someone's personal ngrok tunnel, not a live default; the demo runbook (`docs/DEMO_RUNBOOK_WITNESSED_EXCHANGE.md` line 16) assumes the shared production mediator (`credo-mediator.asml.berkmancenter.org`, Berkman Center's own infrastructure, unreachable to an outside developer); and a stale invitation dead-ends with an unhelpful error (`e2e/README.md` line 75: "There is no mediator to pickup messages from"). This blocks step 2 for *every* demo, including the ready-today trading-card one — it is the single most universal piece of friction found. Fix: mirror the witness precedent — a spin-up script (or documented docker image) for a local Aries mediator agent, injecting its invitation the same way `witness.js` does. Purely additive tooling, no protocol code touched.
+- **R2 — a trimmed starter container**, not just today's 418-line `AppContainer`. Line-level breakdown of the 340 substantive lines (`app/container-imp.ts:99-407`): **~15 lines** are pure container mechanism (constructor, `resolve`/`resolveAll`) — the only part every demo actually needs, already minimal. **~150+ lines are Keyring/BC-Gov production noise with zero explanatory value for a newcomer**: `CACHE_CRED_DEFS`/`CACHE_SCHEMAS` (lines 231-280, ~50 lines) are hardcoded BC Government Indy credential-definition/schema IDs (`Person`, `SellingItRight`, `lawyer`, `member_card`, specific DIDs like `TeT8SJGHruVL9up3Erp4o`) from a different sponsor's production ledger; `CRED_HELP_ACTION_OVERRIDES` (lines 119-139) is four more hardcoded BC `Person` cred-def IDs; the `CONFIG` block (lines 140-223, ~85 lines) mixes a commented-out Help section, commented-out push-notification wiring, BC-specific URLs, and a long comment explaining a *removed* BC Wallet Traction feature. **~90 lines are real Keyring product features that don't generalize**: the `LOAD_STATE` closure (320-397) hydrates Keyring-specific state slices (`witness`, `dismissPersonCredentialOffer`, developer/remote-debugging state) — the *pattern* (load persisted state, dispatch on boot) is needed, just not at this length — and the `NOTIFICATIONS` config (292-317) wires an entire "PersonCredential" auto-offer business flow. **~30-40 lines are genuinely reusable as example registrations**: the screen/component token overrides (`SCREEN_PREFACE`, `COMPONENT_HOME_HEADER`, etc.) show "here's how you swap a token" and are worth keeping as the template's core. Target for a trimmed starter: **60-80 lines** — mechanism + one screen override + one component override + a minimal `LOAD_STATE` + the OCA resolver registration (annotated toward R3), each commented "this is the pattern, replace the payload." Producing it is subtractive (delete BC-specific registrations, keep the pattern) — no new mechanism needed, since the DI container itself already works exactly as required. This is the single highest-friction item the walkthrough found (step 5), and it blocks every use case equally, not just the credential-shaped ones.
+- **R3 — a local/offline OCA resolver option**, registered by default or offered as a documented alternative to `RemoteOCABundleResolver`, so a from-scratch PoC doesn't have to reason about GitHub-raw hosting just to skin one credential.
+- **R4 — a scaffolding convention** — a `demo-profiles/`-style directory sibling to `keyring-theme/` (the existing, currently-unbuilt `app/src/workflow-architecture-example/` is the closest precedent) — so "add a new use case" has one obvious place for a theme + container overrides + Trust Task specs, instead of being invented fresh per demo.
+- **R5 — the open Trust Task type→handler registry + UI renderer** (Patterns item 1 below), needed by every Approver-shaped idea (#1, #3, #5-human, #9) so that step 6 for those ideas means *registering into* `ceremony.ts`, not editing it.
+
+These five are what "Patterns and core requirements" below is in service of: the infra gaps there only matter to the extent they satisfy R1–R5.
+
+---
+
+## Idea-by-idea notes
+
+### 1. The Approver
+"Shows you the real request; never rings for a stranger."
+
+This is the headline PNM capability — `pnm_cnm_subtask.md` §1 calls it out explicitly: *"The highest-value PNM capability — the phone as approver — is gated on none of [TSP/Askar/Credo]."* It's also openvtc-integration-plan.md §6's own MVP: *"browser login via the upstream `demo-rp`; phone shows verified requester, Face ID, in — no password exists. Then an ACL grant attempt from an unverified name → deny → signed refusal in the audit log."*
+
+The message-layer plumbing is real and mature at two levels, not one: `bifold/packages/trust-tasks` (`TrustTaskMessage.ts`, `documentProof.ts`, `validator.ts`) models the transport-neutral document, and — more load-bearing for this idea — `bifold/packages/core/src/modules/trust-tasks/` (the app module current work on `feat/trust-tasks-integration` is actively building) already wraps that in a **generic consume/respond engine**: `TrustTasksService.consume()` takes any `TrustTaskSpecPolicy` (an arbitrary `typeUri` + validation/proof requirements) and a handler callback, runs it through real §7.2 schema validation, proof policy and identity cross-check, and returns via generic `respondWith`/`refuse`. That is not VRC-specific machinery re-purposed — it's already type-agnostic by design.
+
+What *is* still closed and VRC-specific: `setupTrustTasksInbound` in `ceremony.ts` routes an inbound document to a handler via a hardcoded if/else on `document.type` (one branch per known type: `propose`, `propose#response`, `discovery`, `discovery#response`, `issue`, `issue#response`, …), and every existing handler performs automatic protocol business logic rather than surfacing anything to a person. There is no UI anywhere — in this repo or in the §6 brainstorm — that renders an arbitrary incoming Trust Task's payload and lets a user approve/deny it with a signed response.
+
+**Packaging need:** (1) turn `setupTrustTasksInbound`'s if/else into an open registry keyed on `typeUri` (or slug pattern, reusing `slugMatchesPattern` from `ceremony.ts`) that any new demo can add an entry to without touching the ceremony dispatch; (2) a UI-side registry (parallel to `ICredentialDisplayRegistry`) mapping that same `typeUri` to a renderer + approve/deny action. Both sit on top of the existing `TrustTasksService.consume()` engine — no new consumption/response primitive is needed.
+
+### 2. Passkeys Nobody Has to Store
+"One passkey, verified anywhere, stored nowhere."
+
+Directly maps to the hardware attestation stack, which is the most mature, most tested piece of infra in the repo (`docs/HARDWARE_ATTESTATION_FLOW.md` — full status table, real-device E2E, native X.509 chain verification on both platforms). `ensureHardwareSigningKey()` / signing live in `vrc-hardware-signing.ts`, evidence assembly in `EvidenceBuilder.ts`, verification in `BiometricSignatureVerifier.ts` → native `verifyHardwareEvidence`. All of it is currently invoked only from inside VRC credential issuance (`vrc-biometric.ts`), gated by the `useHardwareAttestation` preference.
+
+**Packaging need:** extract "create/reuse a hardware key, sign this payload, produce portable evidence" as a standalone service not coupled to VRC's credential-issuance orchestration, so a demo app can do "sign this login challenge with your Secure Enclave key" without instantiating Credo/DIDComm at all.
+
+### 3. More Factors, Fewer Taps
+"One tap, several kinds of proof." User's own note: rides on The Approver.
+
+The evidence shape already supports composite factor types — `type: ["DeviceAuthentication", "HardwareKeyAttestation"]` / `["BiometricAttestation", "HardwareKeyAttestation"]` (`HARDWARE_ATTESTATION_FLOW.md`, evidence block). Nothing blocks combining more factor types in the same evidence array; the only real work is UI that composes/displays multiple evidence types in one Trust Task response, which is the same rendering-layer gap as #1.
+
+### 4. The Agent Leash
+"An identity and an off switch for any AI agent."
+
+Zero code in this repo, but the concept is already thought through in openvtc-integration-plan.md §6 as **"Meet your Agent"** — the plan's stated post-integration showstopper, not just a name match: *"the LLM never lives inside the VTA — it's a separate process with its own DID, enrolled under a scoped ACL grant (`scopes`, `expiresAt`, `stepUp`, phone holds `approve`)... a prompt-injected agent is rejected/escalated identically — security never depends on the model behaving."* That's the "off switch" (phone-held `approve`/revoke on a scoped grant) and the "identity" (the agent's own DID) both already designed, just not built. §6 estimates "≈1–2 wk on a finished Phase D core."
+
+`auth/sessions/list/0.1`, `auth/revoke-session/0.1`, `vta/credentials/{issue,revoke}` (`pnm_cnm_subtask.md` §11, around line 1143–1227) are **VTA-side operations reached through the PNM client**, and the PNM client itself doesn't exist here — `pnm-cli` / `vta_sdk::client::VtaClient` are Rust, external to this repo, and porting them to RN is exactly what `pnm_cnm_subtask.md` is a *plan* for, not a built thing. Grepping the whole repo for "revoke" turns up only planning documents; there is no "agent" (AI-agent, as opposed to Credo `Agent`) concept anywhere in code.
+
+**Packaging need:** either (a) wait for/build a thin PNM client, or (b) build the demo against a mocked/stub VTA that speaks the same Trust Task document shape (`{id, type, payload}`) so the *wallet-side* approve/revoke UI can be built and demoed now, swapped to a real VTA later. Given the Trust Task envelope is transport-agnostic (`pnm_cnm_subtask.md` §2.1 — REST/DIDComm/TSP all carry the same document), a stub REST VTA is cheap and faithful to the real wire shape.
+
+### 5. Prove You're Human, or an Honest Agent
+User's own note: "Agent half ready; human half a bigger swing" (worth checking with the user — my read of the code suggests it may be the *reverse*, see below).
+
+The "human" half can ride `bifold/packages/verifier` (`ProofRequestTemplate`, `request-templates.ts`) — already the machinery for constructing and sending presentation requests — plus RCard/VRC as the "a person vouched for this identity" signal, plus hardware attestation as a liveness/anti-bot proxy. All three pieces exist and are wired together elsewhere in the app. This half also has a named §6 precedent: the vignette "verified-human interaction (PHC personhood without identity disclosure)" — though §6 only names it, with no design detail beyond the label; the machinery argument above is this file's own contribution, not restated from there. The "honest agent" half needs a *new* credential type an AI agent can hold and present that asserts "I am a bot, and here is what constrains me" — nothing like this exists; DTG credential taxonomy (`DTGCredential` → VRC/VMC/VIC/VPC/VEC/VWC, `openvtc-integration-plan.md` line 498) doesn't have an agent-identity subtype today, so this would need its own spec, likely as a private Trust-Task-adjacent credential rather than a `DTGCredential` subtype (compare: RCard itself is "a VDS, not a `DTGCredential` subtype" — same pattern of needing a new structure rather than forcing an existing taxonomy).
+
+**Flag for the user:** worth revisiting which half is actually "bigger" — the human-proving half has the most reusable infra (verifier + OCA + RCard), the agent half has none.
+
+### 6. Recovery From People, Not Your Inbox
+User's own note: "our biggest swing."
+
+Confirmed: no code anywhere implements social/multi-party recovery. The only near-neighbor concepts in docs are (a) `pnm_cnm_subtask.md` line ~1174, which warns that a UI literally labeled "your recovery phrase" is dangerous framing for a *different* task (local session/device wipe recovery, not social recovery), and (b) `docs/plans/locality-plan/2026-07-20-bam.md`'s "sparse anchor co-witnessing" — physical-proximity-based co-witnessing between devices, a genuinely different mechanism (physics-backed presence, not social vouching for account recovery).
+
+**What it would need:** (1) a way to designate N trusted contacts from existing VRC relationships as recovery guardians, (2) a threshold ceremony to reconstitute key material or re-bind identity — closest structural fit is generalizing the witness protocol's session/challenge pattern (layer C, single-witness today) to multiple parties, (3) UI for issuing and responding to a vouch request. This is the union of gaps #6 and #8 (quorum) — recovery is arguably "quorum + a destructive/security-sensitive outcome," so it should be sequenced *after* quorum, not built in parallel with a separate ceremony.
+
+### 7. An Invite Nobody Can Forward
+User's own note: "waiting on a piece outside our hands."
+
+The OOB invitation/relationship-DID handshake (layer A, `trust_tasks_subtask.md` §2.1) is a `goalCode` + free-text regex negotiation; DIDComm OOB invitations are conventionally single-use, but nothing in this repo enforces "this specific invite was redeemed by the specific person it was meant for" beyond that convention — there's no roster check. That check is described in `pnm_cnm_subtask.md` §1 as living on the **VTC** (Verifiable Trust Community service), not the VTA: *"the join queue, approve/reject, the roster — live on the VTC, not the VTA, and `cnm-cli` cannot reach them."* This matches the user's own assessment — the piece that would make an invite non-forwardable (membership roster + redemption tracking) is server-side infra this repo doesn't own or control.
+
+### 8. The Quorum
+"An approval several trusted people must confirm."
+
+Grep + code read confirm the witness protocol is single-witness only: `WitnessedVRCManager.executeWitnessedExchange` takes one `witnessState`, `witnessStatusStore.ts` and `WitnessConnections.tsx` model exactly one witness relationship, and no "quorum"/"N-of-M"/"multiple witness" term appears anywhere in `bifold/packages/core/src/modules/vrc` or `witness-server`. Marked "Ready to build" on the user's list — my read is that's true in the sense that **no new wire protocol is needed**: the Trust Task message shape (generic request/response, proof requirement, outcome-evidence retention per `trust_tasks_subtask.md` §1) is already generic enough to fan out the same request to M trusted contacts and count responses against a threshold N entirely at the app-orchestration layer, without touching the witness-server's per-session protocol. Worth confirming this reading before treating it as a small lift — it's "no new protocol" but still real new orchestration + UI (fan-out, partial-response state, timeout/threshold logic) that doesn't exist yet.
+
+### 9. Human Factor Authentication
+"A trusted person confirms, with or without the details."
+
+Close cousin of #1, plus one more piece: Trust Task framework 0.3 added `sideEffects` / `exposure` authoring declarations to a spec's front matter (`trust_tasks_subtask.md` §1, point 3). "With or without the details" maps naturally onto rendering the same Trust Task two ways depending on its declared `exposure` class — full payload for the requester, a redacted summary for the confirming party. The `exposure` field already exists in the framework/spec shape; no UI branches on it yet.
+
+### Trading-card exchange app
+Not from the list above, but analyzed the same way.
+
+This is structurally different from the others — not an authorization/approval flow, but a styled credential exchange. It maps almost entirely onto **existing, mature infra**: RCard is already a real credential exchanged over the VRC protocol (`rCardCredential.ts`, `RCardOnboarding.tsx`), and `bifold/packages/oca` ("TypeScript implementation of Overlay Capture Architecture for styling Aries Verifiable Credentials") is already the exact hook the user is describing — a per-credential-type styling/rendering overlay. The credential-display registry (`ICredentialDisplayRegistry`, `map-to-card.ts`, `CredentialCard10.tsx` / `Card11Pure.tsx`) is the existing extension point for "developer decides how their credential/avatar renders." A trading-card demo is very close to: a themed OCA bundle + a custom card renderer registered through that registry, riding the RCard/VRC exchange as transport, plus a profile-picture/avatar field on the credential schema with the "hook for a developer to determine how to make their trading card" being exactly an OCA overlay + display-registry entry. This is the smallest new-code idea on the whole list.
+
+---
+
+## Patterns and core requirements
+
+Cutting across all ten ideas, five infra pieces keep recurring, ranked by how many demos depend on them. Item 1 is R5 from the developer-path section above; items 2–5 are the protocol/credential-layer counterparts to R1–R4's packaging-layer asks — building these is what makes R1–R4's scaffolding have real use-case content to scaffold.
+
+1. **Open Trust Task type→handler registry + a render/approve-deny UI** (needed by #1, #3, #5-human, #8, #9, and useful for #4's stub). This is the single highest-leverage gap, but it is *narrower* than "build a generic consume/respond engine" — that engine (`TrustTasksService.consume()` in `bifold/packages/core/src/modules/trust-tasks/`) already exists, is already type-agnostic, and is being actively built out on `feat/trust-tasks-integration` right now. The two missing pieces are: (a) replacing `ceremony.ts`'s closed if/else dispatch with an open registry keyed on `typeUri`, so a new demo can register a type without touching the ceremony module, and (b) a UI-side registry mapping that same `typeUri` to a renderer + approve/deny action, mirroring the existing `ICredentialDisplayRegistry` pattern. Both are additive on top of live infrastructure, not a parallel system.
+
+2. **Standalone hardware-signing service** (needed by #2, and as a factor inside #3, #5-human). `vrc-hardware-signing.ts` / `EvidenceBuilder.ts` / `BiometricSignatureVerifier.ts` are mature and tested but coupled to VRC issuance. Decoupling "sign this payload with a device key, get verifiable evidence" from VRC's credential-issuance orchestration is a bounded refactor, not new capability — the hard cryptographic/attestation work is already done and proven on real devices.
+
+3. **Witness ceremony generalized from 1 to N-of-M** (needed by #6, #8, and arguably a hardened version of #9). Currently hard-coded to exactly one witness at every layer (manager, store, screen). Recovery (#6) is best understood as quorum (#8) plus a higher-stakes outcome — sequence quorum first.
+
+4. **Credential display extensibility (OCA + display registry)** (needed by the trading-card app, and any "prove you're X" UI in #5/#9). This is already mature and the least-blocked piece on the list — it's the existing answer to "give a developer a hook to control how their credential/avatar looks."
+
+5. **A PNM/VTA client, or a faithful stub of one** (needed by #4, and would substantially help #1 and #7). Doesn't exist in this repo; the real one is an external Rust ecosystem plan (`pnm_cnm_subtask.md`), not yet ported. Because the Trust Task envelope is transport-agnostic and identical across REST/DIDComm/TSP, a minimal REST stub VTA that speaks the same `{id, type, payload}` document shape would let wallet-side UI for #4 (and partially #1, #7) be built and demoed now without waiting on the real VTA/VTC infrastructure — and without throwaway work, since the wallet side wouldn't need to change when a real VTA replaces the stub.
+
+**On packaging mechanics** (how a "reference app + SDK" would actually let a developer pick a use case — the mechanism side of R2–R4):
+
+- The existing `container-api.ts` (tsyringe DI: `SCREEN_TOKENS`, `HOOK_TOKENS`, `PROOF_TOKENS`, `ICredentialDisplayRegistry`, etc.) is already the mechanism Keyring uses to let a downstream app override screens/behavior — extending it with a `TRUST_TASK_TOKENS` renderer registry (item 1 above / R5) keeps this consistent with how the app is already built, rather than inventing a parallel plugin system. **R2 is not "invent a new mechanism"** — it's "produce a trimmed instance of this one," since the mechanism itself is already proven by `AppContainer`.
+- Adding a new `@bifold/*` package (e.g., a decoupled hardware-signing package, or a stub-VTA client) follows the documented four-entry recipe in the root `CLAUDE.md`: root `portal:` resolution, `app/package.json` dependency, `app/metro.config.js` `packageDirs` entry, and (for dev hot-reload) a `BIFOLD_SOURCE_PACKAGES` entry.
+- `app/src/keyring-theme/` is the existing pattern for a full app-identity skin (theme + features); each demo "profile" (Approver demo, trading-card demo, etc.) is naturally a sibling to `keyring-theme/` — a theme + a small set of registered screens/hooks + a handful of Trust Task type specs — rather than a fork of the app. `app/src/workflow-architecture-example/` (currently `.txt`-suffixed, unbuilt reference files for a dynamic-onboarding-workflow pattern) is a precedent for exactly this shape of "example profile" — this is R4's starting point, worth reviewing before designing a new one from scratch.
+- Every new use case that isn't pure UI needs its own Trust Task type spec (`payload.schema.json` per `trust_tasks_subtask.md` §1, point 4) — and per that same document, publishing under a private authority we control is fully conforming (§6.5), so none of these demos need to wait on `trusttasks.org` registry work to exist.
+
+**Sequencing implication:** items 1 and 4 above are the cheapest and unlock the most (Approver, Multi-Factor, HFA, trading-card, and a stubbed Agent-Leash all become buildable). Item 3 (quorum) is next — it's genuinely new orchestration but no new protocol. Items 2 and 5 are each a bounded, mostly-mechanical decoupling of infra that already works. Recovery (#6) and the agent-identity half of #5 are the only two ideas that need real new design work beyond assembly of existing pieces — consistent with the user's own "biggest swing" / "bigger swing" framing for both.

--- a/docs/plans/reference-app-sdk-packaging.md
+++ b/docs/plans/reference-app-sdk-packaging.md
@@ -11,6 +11,7 @@
 | Companion | Author | What it settles |
 |---|---|---|
 | [`2026-09-01-al.md`](./reference-app-sdk-packaging/2026-09-01-al.md) | AL | SDK scope and framing (mobile-first, SDK as the deliverable); consume upstream Trust Tasks rather than reimplement, and the duplicate-implementation problem it exposes; wrap orchestration rather than types; the VTA Farm as first-class onboarding; `ref-08-pnm-core-hermes` as the unblocking experiment; requirements R6–R12 |
+| [`2026-09-03-bm.md`](./reference-app-sdk-packaging/2026-09-03-bm.md) | BM | Fundraising-driven phasing (reference-app track first, SDK track deferred); the one-app/additive-registry/picker architecture; sequencing with hardware-signing decoupling pulled forward; the `feat/trust-tasks-over-didcomm-v1` cross-check that constrains how R5 must be built, and what to tell that branch's owner |
 
 **Reconciled against `openvtc-integration-plan.md` §6 ("Demo concepts — brainstorm only")**, which already proposes several of the same demos under different names, with more ecosystem grounding (real Trust Task type URIs, a stated flagship target). This file's per-idea notes below cite the overlap explicitly rather than treating these as independent proposals:
 
@@ -272,3 +273,67 @@ consumes one.
 is parallel, not downstream); OCA in the SDK core (confirmed absent from the
 Trust Task path — it stays in the reference app for credential-shaped demos); a
 full UI kit (`keyring-theme/` plus two screens is version zero).
+
+---
+
+## Phasing and priorities — 2026-09-03
+
+Recorded here because the plan holds current design; the argument, the
+evidence, and the items to raise with `feat/trust-tasks-over-didcomm-v1` are in
+[`2026-09-03-bm.md`](./reference-app-sdk-packaging/2026-09-03-bm.md), which
+should be read before revisiting any of them.
+
+**Driver.** Packaged, spin-up-and-use demos are needed in the short term for
+fundraising — real, customizable tasks a person outside the team can run and
+extend, not a slide deck. That puts this phase entirely on the reference-app
+track (R1–R5); the SDK track (R6–R17) is deferred, not reversed or
+reprioritized down — nothing above changes because of this section.
+
+**The two demos.** Trading-card exchange (✅ ready — rides the existing
+RCard/VRC exchange, no new engine) and The Approver (🧩 partial — the
+consume/respond engine already exists; the gap is the registry plus a
+render/approve-deny UI). Both are already scored this way in the checklist
+above; this phase adds no new ideas to that list.
+
+**One app, additive registries, a picker — not per-demo forks.** Both demos
+register into the same running build through the existing `container-api.ts`
+token pattern (`TRUST_TASK_TOKENS`, `ICredentialDisplayRegistry`) rather than
+being separate builds or an env flag swapped before rebuild. A home-screen
+chooser lists installed demo profiles (`demo-profiles/`, R4); adding a third
+demo later is dropping in a profile module, no rebuild and no shared-code
+change. This is also the first working instance of this document's proposed
+`registerTrustTask({ spec, orchestration, renderer })` surface — built and
+exercised by our own two demos before any outside developer sees it.
+
+**Sequencing.**
+1. R1 (mediator spin-up script) + R2 (trimmed starter container) — universal
+   blockers for every demo, done once, first.
+2. R3 (local/bundled OCA resolver) + the trading-card demo — smallest new-code
+   footprint on the idea list, ships first.
+3. Hardware-signing decoupling (Patterns item 2 above) — pulled forward from
+   its original sequencing because it is dual-purpose: it lets the approval
+   demo show hardware-backed signing directly, and it is independently one of
+   the SDK's own identified extraction targets. One task instead of two.
+4. R5 (open `typeUri` registry + a generic render/approve-deny screen) — the
+   Approver demo. Built **Carriage-shaped from day one**: the registry's
+   dispatch takes an injected `send`/`onDocument`-style dependency rather than
+   calling `agent.modules.didcomm` directly, even though that is what
+   `ceremony.ts` does today. See the companion for why.
+
+**Pre-demo-day insurance, not a blocker.** T1 (measure whether
+`@bifold/trust-tasks`'s canonicalizer and `@openvtc/trust-tasks`'s diverge) is
+worth running before either demo is shown publicly, since `ceremony.ts`
+genuinely invokes both today. This is the only piece of the T0–T4 remediation
+pulled into this phase; T0, T2, T3, T4 stay deferred.
+
+**Coordination required with `feat/trust-tasks-over-didcomm-v1`.** That
+branch is independently building a `Carriage` port
+(`bifold/packages/trust-tasks/src/carriage.ts`) that abstracts `ceremony.ts`
+away from Credo/DIDComm specifics — the same discipline this phase's R5 work
+needs, arrived at from a different direction (TSP transport pluggability, not
+SDK packaging). It is not yet on `main`. See the companion for what should be
+communicated to whoever owns that branch before R5 starts.
+
+**Out of scope for this phase, restated.** All of R6–R17, and T0/T2–T4 of the
+trust-tasks remediation. They proceed on their own timeline once the
+fundraising demos ship — nothing here re-opens or re-sequences them.

--- a/docs/plans/reference-app-sdk-packaging/2026-09-01-al.md
+++ b/docs/plans/reference-app-sdk-packaging/2026-09-01-al.md
@@ -51,18 +51,37 @@ their `canonical.js` explicitly separates the consumer-local replay digest from
 the §4.9.3 task digest "computed over document ∖ proof" — which is what our
 `taskDigestMultibase` already computes.
 
-### The problem this exposes, and it is load-bearing for Prague
+### The problem this exposes, and it is live today
 
-**`@bifold/trust-tasks` does not depend on `@openvtc/trust-tasks` at all.** It is
-a parallel implementation over `canonicalize` + `ajv` + `@noble/*` + Credo. Our
-pin expects the upstream library at 0.9.0; it is at 0.16.8.
+*Corrected 2026-09-03: an earlier draft of this section said we do not consume
+the upstream package at all. That was wrong, and the accurate picture makes the
+measurement step more urgent rather than less.*
 
-Prague needs `pnm-core` inside Keyring, and `pnm-core` depends on
-`@openvtc/trust-tasks`. So the app would ship **two independent Trust Tasks
-implementations in one bundle** — two JCS canonicalizers, two validators, two
-consume paths. The failure mode is not a build error: it is a digest that
-differs on some unicode or number-formatting edge case, so a signature made by
-one path fails verification on the other, intermittently and per-document.
+We **do** consume upstream. `@openvtc/trust-tasks` is a declared dependency of
+`@bifold/core` and `@bifold/witness-server` at **`^0.9.0`** (installed 0.9.0),
+imported by `ceremony.ts`, `witnessCeremony.ts`, `witnessShareSpec.ts`,
+`TrustTasksService.ts` and the witness-server's `trustTasks/runtime.ts`. The app
+also carries a Metro resolver for its subpaths, because the package's exports
+map declares only `types` and `import` conditions and CommonJS release bundles
+match neither.
+
+What is duplicated is narrower, and it is **already in the bundle**:
+
+- **Two JCS canonicalizers ship today.** `@bifold/trust-tasks`'s
+  `documentProof.ts` canonicalizes with the `canonicalize` package; upstream's
+  `_runtime/canonical.js` implements RFC 8785 itself. Both are in the app now.
+  If they disagree on any input — unicode escaping, surrogate pairs, number
+  formatting — a digest computed by one path will not match the other, so a
+  signature verifies on one side and fails on the other, intermittently and per
+  document. Nothing currently tells us whether they agree.
+- **The version gap is the wider problem.** We are pinned `^0.9.0` while
+  upstream is at **0.16.8** — and framework 0.5.0 landed in between, which is
+  where the two named digests, the document lifecycle table and the freshness
+  rules arrived. `pnm-core` 0.7.0 will want something newer than 0.9.0, so
+  Prague forces this bump rather than merely benefiting from it.
+
+**This raises T1's priority.** The duplicate-canonicalizer risk is not a future
+consequence of bringing PNM in; it is the current state of the bundle, unmeasured.
 
 ### Remediation, phased
 

--- a/docs/plans/reference-app-sdk-packaging/2026-09-01-al.md
+++ b/docs/plans/reference-app-sdk-packaging/2026-09-01-al.md
@@ -1,0 +1,250 @@
+# 2026-09-01 — AL: SDK scope, the trust-tasks split, and what the farm changes
+
+Companion to [`reference-app-sdk-packaging.md`](../reference-app-sdk-packaging.md)
+(PR #24, BM). Written against a research pass over the upstream packages on
+2026-09-01; every version below was checked on npm that day and the ecosystem
+is moving weekly, so re-check before acting.
+
+## What this document settles
+
+The plan as proposed is a **reference-app packaging** plan. The product slate it
+serves needs an **SDK** as well, and the two have different audiences, artifacts
+and release mechanics. This document states the SDK half from the product angle,
+answers whether we consume or reimplement the upstream Trust Tasks library, and
+records what the VTA Farm changes about developer onboarding.
+
+**Framing, stated once:** mobile-first, SDK-focused. The SDK is the deliverable;
+the reference app is what proves it. Where this document says "backend" it means
+*a service that embeds the same library* — not a different product.
+
+## 1. Trust Tasks: consume upstream, own the orchestration
+
+`@openvtc/trust-tasks` (**0.16.8**, zero dependencies) is generated TypeScript
+bindings for the whole framework registry — every task specification's payload
+types plus a `_runtime` carrying `canonicalJson`, `consumeInbound`, freshness,
+replay, transport and error codes. It deliberately does not implement
+cryptography; it **injects** it:
+
+```ts
+proofPolicy:   { kind: "verify", verify: myVerifier }   // ProofVerifier
+payloadPolicy: { kind: "validate", validate: myValidator }
+```
+
+Its own words: *"The framework does not assume what integrity guarantees a
+consumer relies on … Making the choice explicit at the call site is the point."*
+
+**Position adopted.** We consume the upstream package for types and framework
+machinery, and own exactly the two things it leaves blank plus the transport
+binding:
+
+| Layer | Owner | Why |
+|---|---|---|
+| Document types, registry bindings, consume/replay/freshness | `@openvtc/trust-tasks` | Generated from the registry; zero-dep; tracks the spec by construction |
+| A concrete `ProofVerifier` + signer — `eddsa-jcs-2022`, askar keys, **hardware/biometric signing** | us | The blank upstream leaves on purpose, and our actual differentiator |
+| Concrete payload validator | us | Injection point; ajv today |
+| DIDComm binding-0.2 carriage | us | Transport binding, not framework |
+| **Session and relationship orchestration** | us | See §2 — the framework is document-level and says nothing about this |
+
+Two independent confirmations this is the intended split: upstream's own
+`pnm-core` depends on `@openvtc/trust-tasks` rather than reimplementing it, and
+their `canonical.js` explicitly separates the consumer-local replay digest from
+the §4.9.3 task digest "computed over document ∖ proof" — which is what our
+`taskDigestMultibase` already computes.
+
+### The problem this exposes, and it is load-bearing for Prague
+
+**`@bifold/trust-tasks` does not depend on `@openvtc/trust-tasks` at all.** It is
+a parallel implementation over `canonicalize` + `ajv` + `@noble/*` + Credo. Our
+pin expects the upstream library at 0.9.0; it is at 0.16.8.
+
+Prague needs `pnm-core` inside Keyring, and `pnm-core` depends on
+`@openvtc/trust-tasks`. So the app would ship **two independent Trust Tasks
+implementations in one bundle** — two JCS canonicalizers, two validators, two
+consume paths. The failure mode is not a build error: it is a digest that
+differs on some unicode or number-formatting edge case, so a signature made by
+one path fails verification on the other, intermittently and per-document.
+
+### Remediation, phased
+
+Sequenced so that the risky step is measured before it is taken, and so that
+nothing here blocks the Prague work in parallel.
+
+- **T0 — advance the pins first.** Bump `@openvtc/trust-tasks` to current,
+  `pnm-core` 0.4.0 → **0.7.0**, `vti-didcomm-js` 0.6.2 → **0.7.0**, log the
+  advance, and re-run the reference ladder bottom-up. Measuring against a
+  five-day-stale view of the ecosystem would only have to be redone.
+- **T1 — prove or disprove the divergence, before changing any code.** A new
+  rung that runs our `jcsCanonicalize` (the `canonicalize` package) and
+  upstream's `canonicalJson` over one corpus — unicode escapes and surrogate
+  pairs, number formatting, deep member ordering, empty and absent members —
+  and compares both the canonical bytes and the resulting `taskDigestMultibase`.
+  Two outcomes, both useful: byte-identical means the migration is a safe
+  swap and T2 is mechanical; any divergence names the exact input class that
+  would have produced intermittent cross-implementation signature failures, and
+  becomes a fixture we keep forever. **This is the cheapest step and the one
+  that decides how careful the rest has to be — do it first.**
+- **T2 — re-point, do not re-implement.** Add `@openvtc/trust-tasks` as a
+  dependency of `@bifold/trust-tasks`; adopt its document types and
+  `consumeInbound`; keep our `eddsa-jcs-2022` signer and verifier as the
+  injected `ProofVerifier`, our validator as the injected `payloadPolicy`, and
+  the binding-0.2 carriage. Delete our duplicated document and canonicalization
+  layer and the `canonicalize` dependency with it.
+- **T3 — split pure from adapter** (§1, second constraint): a Credo-free pure
+  layer that the wallet, witness, VTA and any relying-party service can share,
+  and a Credo adapter for askar keys and DIDComm carriage.
+- **T4 — guard it.** A check that fails the build when more than one JCS
+  canonicalizer resolves in the bundle, so the duplicate cannot come back by
+  way of a transitive dependency.
+
+**Ordering note.** T0 and T1 are independent of everything else in this plan and
+should happen regardless of what the packaging work decides — the divergence
+either exists today or it does not, and we currently do not know which.
+
+### A second constraint on the same package
+
+`@bifold/trust-tasks` is platform-neutral (no `fs`, no React Native) but
+**depends on Credo** (`@credo-ts/core` patched, `@credo-ts/didcomm`). A relying
+party embedding our SDK to ask for an approval should not be made to install an
+agent framework. The package therefore wants splitting along a second axis:
+
+- **pure layer** — documents, proofs, digests, validation (noble + JCS only)
+- **Credo adapter** — askar key handles, DIDComm carriage, wallet integration
+
+The pure layer is what a witness, a VTA, a relying-party service and the wallet
+can all share; the adapter is wallet-and-witness only.
+
+## 2. Yes, we wrap — but we wrap orchestration, not types
+
+The framework is document-level. Everything below is real Keyring behaviour with
+no upstream equivalent, all of it in `bifold/packages/core/src/modules/trust-tasks/ceremony.ts`:
+
+- **Who proposes.** When both peers could initiate, `isDeterministicProposer`
+  breaks the tie from the two DIDs so the exchange does not double-start.
+- **Whether the peer can play.** `peerSupportsTaskType` resolves support from
+  stored discovery documents before a task is attempted.
+- **Version gating.** `TRUST_TASKS_MIN_RCE_VERSION` refuses exchanges with peers
+  too old to complete them.
+- **Persistence and idempotence.** Documents are stored and re-queried by
+  `{typeUri, connectionId}` so a re-delivered proposal does not re-run.
+- **Flow interlocks.** A ceremony will not start while
+  `vrcFlowStore.getStatus(connectionId)` is not idle.
+
+That is the SDK's product surface: **a session object over a relationship**, not
+a re-export of upstream types. A developer should be able to say "run this task
+with this contact" and have proposer selection, capability discovery, version
+gating and idempotence handled. Re-exporting `TrustTaskDocument` adds nothing;
+owning the session does.
+
+**Consequence for the plan's R5.** An open `typeUri` → handler registry is
+necessary but not sufficient: registration has to carry the payload spec, the
+renderer, *and* the orchestration policy (who proposes, what the peer must
+support, what happens on redelivery). R5 should be specified as
+`registerTrustTask({ spec, orchestration, renderer })`, not as a dispatch table.
+
+## 3. The Trust Tasks library is consumed by backends *and* the wallet
+
+Recorded because it keeps coming up: the same library is embedded by
+
+- the **wallet** (React Native / Hermes),
+- the **witness-server** (Node — it already consumes `@bifold/trust-tasks`
+  today, in `src/trustTasks/WitnessTaskSessions.ts`),
+- the **VTA** (Rust, upstream, embeds its own),
+- and a **relying-party service**, if we build the product slate's approval API.
+
+So there is no separate "Trust Tasks backend" to build. There are services that
+embed a platform-neutral library, which is exactly why the pure layer in §1 must
+stay free of Credo, React Native and Node.
+
+## 4. What the VTA Farm changes
+
+Per upstream's own developer guide, Path A ([VTA Farm](https://vtafarm.firstperson.dev/),
+managed Kubernetes) gives a developer VTA hosting, DID hosting and mediator
+connection management with no server and no public domain; Path B (self-hosted)
+means an Ubuntu host, publishing `did:webvh` logs over public HTTPS, and wiring a
+community mediator by hand. Upstream recommends Path A for newcomers.
+
+**Position adopted.** The Farm is the first-class onboarding path, and the plan's
+R1 becomes *point a developer at the Farm* rather than *hand them a compose file
+for a VTA*. Self-hosting stays documented as Path B, where
+`tsp-reference/ref-05-local-vta` is already the precedent.
+
+**Open question, and it gates the Agent Leash.** Path A's stated prerequisites
+are a Farm account, **passkey support**, and locally installed PNM software —
+that is the browser plugin. A React Native wallet needs the VTA's REST/DIDComm
+surface (probed in `ref-06x-cypress-stack`) and an authentication path that does
+not require WebAuthn. Whether a mobile wallet can authenticate to a Farm-hosted
+VTA is unanswered, and it is the same question as §5.
+
+## 5. The unblocking experiment: `pnm-core` under Hermes
+
+`@openvtc/pnm-core` **0.7.0** — the `packages/core` workspace of the plugin repo
+— contains a complete TypeScript VTA client under `src/vta/`: `client.ts`,
+`auth.ts`, `auth-tasks.ts`, `channel.ts`, `didcomm.ts`, `discovery.ts`,
+`endpoint.ts`, `mediation.ts`, `mediator-client.ts`, `list-dids.ts`,
+`bridge-mediator-session.ts`.
+
+Its dependency stack — `@noble/curves`, `@scure/base`, `@cfworker/json-schema`,
+`cbor-x`, `@openvtc/trust-tasks`, `vti-didcomm-js`, `vti-tsp-js` — is pure
+JavaScript with no WebCrypto and no Node built-ins, which is the same path
+`ref-03-noble-crypto` already proved runs under Hermes. But it is described as
+browser-side, its passkey half is WebAuthn, and **nothing in the source mentions
+React Native or Hermes**.
+
+**Next rung: `ref-08-pnm-core-hermes`.** Prove the VTA client runs under Hermes
+and identify precisely which parts are browser-bound (WebAuthn, storage,
+`cbor-x`'s native accelerator) against which are portable. One experiment
+answers three questions that the rest of this plan is currently guessing at:
+
+1. Can Keyring talk to a Farm-hosted VTA at all (§4)?
+2. Is the Agent Leash a port or a rewrite?
+3. Does our SDK own a VTA client, or consume `pnm-core`?
+
+Everything else in the packaging plan can proceed in parallel; this one is on the
+critical path and is days, not quarters.
+
+## 6. SDK requirements this document adds to the plan
+
+Numbered to continue the plan's R1–R5. Each is absent from PR #24.
+
+- **R6 — versioning and publishing.** There is no publish pipeline in this repo
+  at all: CI is `quality.yml` plus two staging deploys. Needed: semver per
+  package, coordinated bumps, npm provenance on publish, and a public-API report
+  gate so a surface change fails CI without a docs update. `@bifold/core` is
+  published (3.0.22); **`@bifold/trust-tasks` is not published at all.**
+- **R7 — the package inventory, with dependency direction drawn before
+  extraction.** The SDK spans more than Trust Tasks: VRC exchange, witness and
+  locality (branch pending merge), hardware signing (currently coupled to VRC
+  issuance), and a VTA client (port or reimplement — pending §5).
+- **R8 — error taxonomy as a product surface.** Stable codes, a request or
+  document identifier on every failure, and documentation keyed to those codes.
+  Upstream's `_runtime/codes.ts` is the vocabulary to align with rather than
+  invent against.
+- **R9 — a VTC administration reference app.** Operators need roster, membership
+  and policy views; Wikimedia Foundation is the named client shaping it. Check
+  `vtc-service`'s existing admin routes first — this may be a UI over an API
+  that already exists rather than a new service.
+- **R10 — documentation in multiple languages.** Translate the guides;
+  machine-generate the API reference and leave it untranslated. The app already
+  ships localization infrastructure, so the pattern exists.
+- **R11 — a compatibility matrix.** SDK vN against app vN−1, and
+  `yarn e2e:vrc:devices` as the mandatory gate for anything touching hardware
+  signing, since emulators cannot prove attestation.
+- **R12 — supply-chain posture.** Prefer the smallest dependency trees (the
+  upstream Trust Tasks library has zero), pin CI actions by SHA, and gate
+  dependency additions. Upstream pinned their own actions by SHA this week; the
+  same discipline applies here.
+
+## 7. What is explicitly out of scope here
+
+- **Prague.** Prague connects Keyring directly to the Farm. This plan is
+  parallel and related, not upstream of it. Nothing here should be sequenced
+  against the summit date.
+- **OCA.** Confirmed not in the Trust Task path — zero occurrences in
+  `modules/trust-tasks/`; only `@bifold/core` depends on `@bifold/oca`. It stays
+  out of the SDK core and remains in the reference app for credential-shaped
+  demos. One caveat: R5's payload renderer needs a declarative render layer,
+  which is the problem OCA already solves — check whether its resolver interface
+  can carry task payloads before inventing a second overlay system.
+- **A UI kit.** `app/src/keyring-theme/` is the de-facto kit; theme plus two
+  screens is version zero. A full kit competes with R2 and R4 for the same
+  effort.

--- a/docs/plans/reference-app-sdk-packaging/2026-09-01-al.md
+++ b/docs/plans/reference-app-sdk-packaging/2026-09-01-al.md
@@ -234,6 +234,122 @@ Numbered to continue the plan's R1–R5. Each is absent from PR #24.
   dependency additions. Upstream pinned their own actions by SHA this week; the
   same discipline applies here.
 
+## 6b. Requirements continued — documentation, conventions, distribution
+
+- **R13 — documentation stack, hosting, and agent-readability.** One extractor,
+  one site, one gate:
+  - **Extractor:** TypeDoc for the API reference, emitting JSON as well as HTML
+    so the reference can be published inside the guide site rather than beside
+    it. **API Extractor** produces the API report that R6's CI gate reads — that
+    report is what makes "documentation that updates itself" real: a change to
+    the public surface fails the build until the docs change with it. Generated
+    reference alone does not achieve this, because what actually rots is the
+    guides, and no generator fixes that.
+  - **Site:** a static guide site (Docusaurus or Starlight) consuming that JSON.
+  - **Hosted at a stable, versioned address** — a subdomain we control, e.g.
+    `keyring.appliedtechnologylab.org/documentation`. Versioned docs and the
+    marketing page have different lifecycles and should not share a URL space
+    (see R16).
+  - **Agent-readable by construction:** an `llms.txt` index and an `AGENTS.md`
+    (equivalently `CLAUDE.md`) in the SDK repo and in each generated starter, so
+    a developer's coding agent can act on the SDK without a human paraphrasing
+    the docs first. Cheap, additive, and increasingly expected.
+  - **Content floor, not optional:** a getting-started path that walks the
+    typical flow end to end, a stated minimum-requirements section (Node,
+    Xcode/Android SDK, a mediator or Farm account, device requirements for
+    attestation), and **diagrams** for the exchange flows — the sequence
+    diagrams are the part developers actually read, and the witnessed exchange
+    is not comprehensible from prose.
+  - Where the SDK exposes HTTP surfaces, the same site carries the API reference
+    generated from a specification rather than hand-written.
+
+- **R14 — SDK conventions borrowed from mature SDKs.** Worth taking from Stripe,
+  Twilio, Plaid and the cloud vendors, in the order they matter here:
+  1. **A sandbox.** Every one of those SDKs has a test mode you can use before
+     you have credentials or infrastructure. Ours is the local stack plus the
+     Farm — which means **R1 is not developer-experience polish, it is table
+     stakes**, and should be sequenced as such.
+  2. **No breaking change without a major**, and a documented support window.
+  3. **An identifier on every failure** — the document `id` or `threadId` — so a
+     developer can quote one string in a support request and we can find it.
+     This is the operational half of R8.
+  4. **Idempotence made explicit in the API**, since the Trust Task layer
+     already implies it (documents queried by `{typeUri, connectionId}`) and a
+     developer should not have to discover that by experiment.
+
+- **R15 — an intake channel for builders.** A place to report issues and get
+  answers, staffed enough to answer. Publishing an SDK creates a support
+  obligation whether or not a channel exists; the only choice is whether the
+  reports arrive somewhere we watch.
+
+- **R16 — a showcase surface, kept separate from the docs.** Reuse the existing
+  lab site (`appliedtechnologylab.org/projects#keyring`) rather than standing up
+  a new site — but keep it distinct from R13's versioned documentation, because
+  a marketing page and a docs tree have different lifecycles and audiences.
+
+- **R17 — a multi-language strategy that survives contact with our crypto.** The
+  SDK generators built for this (Speakeasy, Stainless, Fern) generate from
+  OpenAPI, and our product is a document-and-signature contract, not a REST
+  surface: they would emit HTTP clients but not JCS canonicalization or Ed25519
+  verification — the part that makes the response checkable rather than trusted.
+  **Publish conformance test vectors instead**, the way
+  `tsp-reference/ref-03-noble-crypto` reproduces the CFRG vectors: any language's
+  implementation can then be *proven* correct against them, and a thin REST
+  client per language becomes trivial. Sequence the language set behind an
+  audience question — Swift and Kotlin exist for native app developers, Python
+  and Go for relying-party services — and answer it before generating anything.
+
+## 6c. Two acceptance criteria, stated so they can fail
+
+- **The reference app consumes the published SDK.** Not the source, not a
+  workspace path — the artifact a developer would install. If the reference app
+  can only be built against the monorepo, the SDK is not a product and the
+  packaging has not been tested.
+- **"Stupid easy" is measured, not asserted.** The stated goal is that an
+  outside developer reaches a working exchange quickly. Make that a timed
+  walkthrough by someone who has not seen the repo, recorded with the number
+  they actually hit. The walkthrough in the notes above already establishes the
+  current figure is a day or two for the *easiest* demo; a packaging change that
+  does not move that number has not delivered.
+
+## 6d. Check upstream before building — three overlaps found
+
+"Easy to integrate with existing infrastructure" has concrete upstream answers
+already, and two of them overlap the product slate directly:
+
+- **`@openvtc/rp-sdk` 0.2.0** — "server-side SDK for Relying Parties consuming
+  SIOPv2 id_tokens from the OpenVTC browser plugin", dependencies `@noble/*`
+  and `@scure/base`. This is upstream's own answer to the relying-party surface
+  the product slate's approval API describes. Decide deliberately whether to
+  contribute to it or build a second one; do not arrive at a second one by
+  default.
+- **`@openvtc/pnm-core` 0.7.0** — "browser-side bridge between WebAuthn
+  passkeys and VTA-managed DIDs". That is substantially the "Passkeys Nobody Has
+  to Store" product's core mechanism. Establish the overlap before scheduling
+  that item.
+- **`vtc-service`** already exposes administrative routes (relationship graph,
+  ACLs), so R9's administration app may be a user interface over an existing API
+  rather than a new service.
+
+## 6e. Two risks in the product slate, recorded here rather than lost
+
+- **The identity model in the slate contradicts the privacy position we argued
+  publicly this week.** The slate shows an approval attributed to
+  `did:web:sam.keyring.app` — a per-user `did:web` under one shared origin. That
+  is precisely the correlation surface the DTG credential specification's new
+  Privacy Consideration 7 warns about (several of a party's identifiers
+  resolving through common infrastructure lets that infrastructure associate
+  them), and we supported that text in review. It also breaks the slate's own
+  claim that the proof still verifies if we disappear, since the DID would stop
+  resolving. Use identifiers the user controls — pairwise, `did:key`, or
+  `did:webvh` under their own control.
+- **"Ready to build" in the slate and the triage above disagree on three
+  items.** The Agent Leash has no VTA client in this repo; the Quorum's witness
+  protocol is single-witness at every layer; and Human Factor Authentication's
+  headline behaviour ("you decide what she sees") depends on the Trust Task
+  `exposure` field, which is confirmed unused in the codebase. Ready-to-*start*
+  is a fair reading, but an external audience will not hear it that way.
+
 ## 7. What is explicitly out of scope here
 
 - **Prague.** Prague connects Keyring directly to the Farm. This plan is

--- a/docs/plans/reference-app-sdk-packaging/2026-09-03-bm.md
+++ b/docs/plans/reference-app-sdk-packaging/2026-09-03-bm.md
@@ -1,0 +1,194 @@
+# 2026-09-03 — BM: fundraising phasing, the multi-demo architecture, and what it finds in `feat/trust-tasks-over-didcomm-v1`
+
+Companion to [`reference-app-sdk-packaging.md`](../reference-app-sdk-packaging.md)
+(PR #24). Records the phasing decision driven by an external deadline, the
+architecture that satisfies two constraints on it at once, and a cross-check
+against other in-flight work that changes how the highest-risk piece (R5)
+should be built.
+
+## What this document settles
+
+The lab director has asked for packaged demos — something a person outside
+the team can spin up and use, or integrate to do a meaningful task — available
+in the short term for fundraising. That request decides the phasing question
+2026-09-01-al.md's SDK framing raised: **this phase is entirely the
+reference-app track (R1–R5).** None of R6–R17 (versioning, publishing, the
+Credo/pure package split, docs infra, multi-language conformance vectors) is
+needed to hand someone a working, customizable demo, and none of it is
+touched here. This is a phasing decision, not a reversal of 2026-09-01-al.md —
+the SDK positions adopted there stand; they are just not what this phase
+builds.
+
+Two further constraints came from the same conversation and are folded into
+the architecture below rather than treated as separate work: (1) one app
+should support enabling more than one demo with a few clicks or a small code
+change, not a rebuild or a fork per demo; (2) what gets built now should not
+require major rework when the SDK track eventually starts.
+
+## Decision: two demos, already scored correctly
+
+**Trading-card exchange** (✅ ready — rides the existing RCard/VRC exchange
+and OCA display registry, no new engine) and **The Approver** (🧩 partial —
+`TrustTasksService.consume()` already exists and is generic; the gap is the
+`ceremony.ts` if/else → open registry plus a render/approve-deny UI). Both
+are already scored this way in the checklist above this document; nothing new
+is being added to the idea list. Approval was chosen as the second demo over
+the other 🧩-partial ideas (More Factors, HFA) because it is the one with no
+prerequisite dependency on Approver's own registry — the other two *ride* it.
+
+## Decision: one app, additive registries, a picker — not per-demo forks
+
+Satisfying "a few clicks enable another demo" and "don't design something
+that gets thrown away for the SDK" turn out to be the same design, not two:
+
+Both demos register into the same running build through the container's
+existing token pattern (`container-api.ts`'s `TRUST_TASK_TOKENS`,
+`ICredentialDisplayRegistry`) rather than being separate builds selected by an
+env flag at build time. A home screen lists installed demo profiles
+(`demo-profiles/`, R4) and lets the person tap between them live, in one
+running app. Adding a third demo later is: drop in a profile module; it
+appears in the picker without touching shared code.
+
+This is deliberately more UI work up front than a single hardcoded demo (the
+chooser screen) or a rebuild-with-env-var approach, and worth it for two
+reasons: it is what "a few clicks" literally means to someone at a table with
+a funder, and it is simultaneously the first working instance of
+2026-09-01-al.md §2's proposed `registerTrustTask({ spec, orchestration,
+renderer })` surface — built and exercised by our own two demos before any
+outside developer ever sees it, rather than designed speculatively and
+untested until the SDK phase.
+
+## Decision: sequencing, with one item pulled forward
+
+1. **R1 (mediator spin-up script) + R2 (trimmed starter container) first.**
+   Both are universal blockers found by the developer-path walkthrough above
+   ("blocks step 2 for every demo... the single most universal piece of
+   friction" / "the single highest-friction item... blocks every use case
+   equally"); doing them once benefits both demos. One caution on R2: some of
+   what the walkthrough calls BC-Gov cruft (`CACHE_CRED_DEFS` and friends) may
+   or may not still be live in Keyring's own product — confirm it is
+   genuinely dead before deleting, so a demo-prep trim does not break the main
+   app.
+2. **R3 (local/bundled OCA resolver) + the trading-card demo.** Smallest
+   new-code footprint on the whole idea list; ships first. Depending on
+   `RemoteOCABundleResolver` against a public GitHub-raw URL is an avoidable
+   failure point for a funder-facing demo, self-service or live.
+3. **Hardware-signing decoupling (Patterns item 2), pulled forward.** Originally
+   sequenced later as a bounded, independent refactor; moved up here because
+   it is dual-purpose — it lets the approval demo show hardware-backed signing
+   directly ("signed with the Secure Enclave, no password"), and it is
+   independently one of the SDK's own identified extraction targets (Patterns
+   item 2 above). One task instead of two.
+4. **R5 (open registry + render/approve-deny UI) for the Approver demo.**
+   Sequencing and construction constrained by the finding below — this is the
+   item that changed shape today.
+
+**Pre-demo-day insurance, not a blocker:** run T1 from 2026-09-01-al.md
+(measure whether `@bifold/trust-tasks`'s canonicalizer and
+`@openvtc/trust-tasks`'s diverge) before either demo is shown publicly.
+`ceremony.ts` genuinely invokes both today, so the risk is live in the exact
+path both demos exercise; T1 is cheap (a corpus diff, not a migration) and the
+alternative is an intermittent signature failure with no build error,
+happening live. T0, T2, T3, T4 of that remediation stay deferred — this phase
+pulls in only the measurement.
+
+## Finding: `feat/trust-tasks-over-didcomm-v1` already builds part of what T3 asks for — and it changes how R5 must be built
+
+Checked the worktree at `.claude/worktrees/trust-tasks-over-didcomm-v1`
+(branch `feat/trust-tasks-over-didcomm-v1`, HEAD `d84d358` at the time of this
+check, no open PR yet) against `main`.
+
+**On `main` today**, `ceremony.ts` calls Credo's DIDComm API directly,
+throughout the file — eleven `agent.modules.didcomm.connections.getById(...)`
+call sites plus a direct `messageSender.sendMessage(...)`. There is no
+transport-abstraction seam.
+
+**On the TSP branch**, that seam now exists:
+`bifold/packages/trust-tasks/src/carriage.ts` defines a `Carriage` port
+(`send(document, peer)`, `onDocument(handler)`), with its own header citing
+`openvtc-integration-plan.md §5.2`: *"The task model depends on a `Carriage`
+port, not on the TSP wire."* Two implementations sit behind it —
+`module/DidCommV1Carriage.ts` (today's transport) and `module/TspCarriage.ts`
+(new, gated behind `setTspCarriageEnabled`, not default) — plus a Credo-free
+`packages/trust-tasks/src/tsp/` directory (`direct.ts`, `hpke.ts`, `ports.ts`)
+and a new `messages/TspEnvelopeMessage.ts`. It has real test coverage
+(`ceremony.test.ts`, `tspCarriage.test.ts`, `tspEnvelope.test.ts`).
+
+This is exactly the "keep Credo/transport behind a thin interface" discipline
+2026-09-01-al.md's §1 second-constraint argument (the pure/Credo-adapter
+split, there aimed at T3) calls for — arrived at independently, from transport
+pluggability for TSP rather than from SDK packaging. It is strong evidence
+that split is practically achievable, not aspirational: someone has already
+built it and it passes its own tests. **Whoever is sequencing T0–T4 should
+revisit T3's cost once this branch lands — a meaningful part of it may already
+be done.**
+
+It also means: if R5's registry work modifies today's direct-Credo
+`ceremony.ts`, that code gets structurally reworked out from under it the
+moment this branch merges — not rebased, reworked, since the dispatch
+mechanism itself is what is changing shape.
+
+**Decision, superseding the plain reading of R5 in 2026-09-01-al.md §2:**
+R5's registry dispatch is **built Carriage-shaped from day one** — it takes an
+injected `send` / `onDocument`-style dependency, matching `Carriage`'s actual
+shape, rather than calling `agent.modules.didcomm` directly the way the rest
+of today's `ceremony.ts` does. When the real `Carriage` lands on `main`,
+wiring the registry to it is a substitution, not a rewrite. This is worth the
+small extra indirection now specifically to avoid the "major rework later"
+outcome the director's second ask was about.
+
+Preferred alternative, if timeline allows: get the TSP branch's `Carriage`
+refactor itself reviewed and landed before starting R5, and build the
+registry directly against it. See the communication section below — this
+should be raised with whoever owns that branch rather than decided
+unilaterally here.
+
+## Finding: mediator reliability is already being hardened elsewhere — narrows R1
+
+A second worktree, `fix/mediator-pickup-strategy` (mostly pushed, one local
+commit ahead of `origin`), is independently fixing mediator message-pickup
+reliability: explicit pickup everywhere, resuming pickup when the app returns
+to foreground, hardening against `.env` transport drift. This is a different
+problem from R1 (there is still no local-mediator spin-up tooling anywhere,
+mirroring `e2e/lib/witness.js`), but it removes a risk that would otherwise
+undermine R1's value: standing up a one-command local mediator is not worth
+much if the app's pickup behavior is separately flaky. R1's scope stays
+exactly what it was — spin-up tooling — but its payoff depends on this
+branch's fixes landing first or alongside it.
+
+## What should be communicated to whoever owns `feat/trust-tasks-over-didcomm-v1`
+
+1. **Heads-up on file contention.** The Approver demo (R5) is about to add an
+   open `typeUri` registry to `ceremony.ts`, replacing today's if/else
+   dispatch. That file is also where the `Carriage` refactor lives. Whoever
+   gets there first should say so before doing large restructuring, so the
+   other side doesn't spend time resolving a conflict that coordination would
+   have avoided.
+2. **Ask: how close is `Carriage` to merge?** If it's close, we would rather
+   sequence R5 after it and build the registry against the real port once. If
+   it's weeks out, we'll proceed with an injected `send`/`onDocument`
+   dependency shaped to match `Carriage` and expect a follow-up wiring change
+   when it lands — flagging that now so it isn't a surprise later.
+3. **Tell them what their work is already doing for the SDK plan.** The
+   `Carriage` port is a real instance of the pure/Credo-adapter split
+   2026-09-01-al.md's T3 asks for, built for an unrelated reason (TSP
+   transport pluggability). Worth them knowing so the SDK remediation
+   sequencing accounts for it rather than duplicating it later, and so credit
+   for that groundwork isn't lost when T3 is scoped.
+4. **Ask whether they already have (or are about to build) an open
+   type→handler registry of their own** for dispatching inbound documents
+   through `Carriage`. If so, R5 should register into that mechanism rather
+   than building a second, incompatible one — this is exactly the kind of
+   duplication the demo work is trying to avoid causing elsewhere.
+5. **Agree on Trust Task type-URI namespacing now.** Both efforts mint type
+   URIs under a private authority (`trust_tasks_subtask.md` §6.5: publishing
+   under an authority we control is fully conforming). Confirm the demo
+   types (trading-card avatar extension, the approval task types) and
+   whatever the TSP work mints don't collide, and agree on one naming
+   convention rather than each side inventing its own.
+6. **Low-priority check, not confirmed as a conflict:** `vrc-hardware-signing.ts`
+   shows unrelated recent changes on that branch's bifold history (biometrics
+   enabling hardware-backed signing). Worth a quick sync before starting the
+   hardware-signing decoupling work (sequencing item 3 above) in case there's
+   overlap, though nothing found so far suggests the TSP branch is touching
+   the decoupling itself.


### PR DESCRIPTION
## Summary
- Exploratory checklist + per-idea analysis of packaging this repo as a reference app + SDK, so prospective developers can try distinct identity/credential use cases (The Approver, Passkeys, More Factors, The Agent Leash, Prove You're Human, Recovery, non-forwardable invites, The Quorum, Human Factor Authentication, and a trading-card exchange demo).
- Reconciled against `openvtc-integration-plan.md` §6's own "Demo concepts" brainstorm — cites the overlap explicitly (e.g. Agent Leash ≈ "Meet your Agent") rather than treating these as independent proposals, and corrects an early research pass that missed `bifold/packages/core/src/modules/trust-tasks/`'s already-generic consume/respond engine.
- Adds a "developer path" section, walked concretely (clone → mediator → build → theme → DI wiring → register content → exchange), with five requirements (R1–R5) derived from real friction found in that walkthrough — most notably the 418-line `AppContainer` having no trimmed starter template, and no local-mediator tooling equivalent to the witness spin-up script.
- Status: exploratory notes, not a commitment to implement — flagged in the doc itself, not yet split into a proper plan + dated companions per `docs/plans/CLAUDE.md`.

## Test plan
- [x] Docs-only change; no app code touched.
- [x] `yarn typecheck` / lint ran clean via the pre-commit hook.
- [x] Pre-push test suite ran clean (16 suites, 70 tests).