### PR TITLE
fix(mediation): explicit message pickup; e2e hardening; bifold bump

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Note: emulators/simulators cannot do hardware attestation — the app silently f
 ## Commit conventions
 
 - Conventional commits enforced by commitlint: `feat|fix|docs|style|refactor|perf|test|chore|revert`, lower-case type.
-- Commits in the `bifold/` submodule require `Signed-off-by: Alberto L <aleon@law.harvard.edu>` as the **last line** of the message (commitlint rejects anything after it). Do not add agent co-author trailers to bifold commits.
+- Commits in the `bifold/` submodule require a `Signed-off-by:` trailer as the **last line** of the message (commitlint rejects anything after it), naming the commit's own author — i.e. your configured `user.name` / `user.email`, the same as `git commit -s` produces. A sign-off is an attestation by whoever made the commit, so never sign off as another contributor. Do not add agent co-author trailers to bifold commits.
 - For message-only rewrites in bifold, use `git commit-tree -S` (SSH signing) to keep commits Verified; fallback `git commit -S -F msg.txt` with `HUSKY=0`.
 
 ## Ongoing upgrade work

--- a/app/metro.config.js
+++ b/app/metro.config.js
@@ -205,17 +205,25 @@ module.exports = (async () => {
         // condition to match.
         if (moduleName.startsWith('@openvtc/trust-tasks/')) {
           const subPath = moduleName.slice('@openvtc/trust-tasks/'.length)
-          for (const base of [
+          const bases = [
             path.join(__dirname, 'node_modules'),
             path.join(__dirname, '..', 'bifold', 'packages', 'core', 'node_modules'),
             path.join(__dirname, '..', 'bifold', 'node_modules'),
             path.join(__dirname, '..', 'node_modules'),
-          ]) {
+          ]
+          for (const base of bases) {
             const candidate = path.join(base, '@openvtc', 'trust-tasks', 'dist', `${subPath}.js`)
             if (fs.existsSync(candidate)) {
               return { filePath: candidate, type: 'sourceFile' }
             }
           }
+          // No dist/<subPath>.js in any base — falling through to Metro's default
+          // resolution would just reproduce the "no match was resolved" failure
+          // this block exists to work around. Fail loudly instead.
+          throw new Error(
+            `[metro.config] Could not resolve '${moduleName}': no dist/${subPath}.js found under any of:\n` +
+              bases.map((base) => `  ${path.join(base, '@openvtc', 'trust-tasks', 'dist', `${subPath}.js`)}`).join('\n')
+          )
         }
         // Intercept rdf-canonize package requests to ensure patched version is used
         if (moduleName === 'rdf-canonize' || moduleName.startsWith('rdf-canonize/')) {

--- a/app/src/hooks/useBCAgentSetup.ts
+++ b/app/src/hooks/useBCAgentSetup.ts
@@ -66,6 +66,18 @@ const loadCachedLedgers = async (): Promise<IndyVdrPoolConfig[] | undefined> => 
 // request/ack'd against the mediator's queue and each poll self-heals a dead
 // socket. Revisit live mode once the mediator requeues unacked live deliveries.
 const configureMessagePickup = async (agent: Agent): Promise<void> => {
+  // Stop the pickup credo already started during agent.initialize() before
+  // starting ours. initiateMessagePickup SUBSCRIBES A NEW polling interval on
+  // every call — it does not replace the previous one — so without this we run
+  // two concurrent loops and double this wallet's request rate against the
+  // shared mediator (at the 1s interval below, ~172k requests/day per idle
+  // wallet instead of ~86k). Observed on the witness-server 2026-08-31.
+  await agent.modules.didcomm.mediationRecipient.stopMessagePickup()
+
+  // Pass the strategy EXPLICITLY: credo otherwise resolves it as
+  // `mediationRecord.pickupStrategy ?? moduleConfig`, and a value persisted in
+  // the wallet outranks the config — which is how the same code ends up
+  // receiving messages on one wallet and deaf on another.
   await agent.modules.didcomm.mediationRecipient.initiateMessagePickup(
     undefined,
     DidCommMediatorPickupStrategy.PickUpV2

--- a/app/src/hooks/useBCAgentSetup.ts
+++ b/app/src/hooks/useBCAgentSetup.ts
@@ -37,12 +37,24 @@ import { BCState, BCLocalStorageKeys } from '@/store'
  * stale socket kills a DIDComm exchange. OkHttp on Android retries stale
  * pooled connections transparently — this restores parity by retrying the
  * send once on a fresh connection. See docs/spikes/e2e-vrc-connect-findings.md.
+ *
+ * Only that specific symptom is retried: CredoError wraps the fetch-layer
+ * failure as `cause`, and "Network request failed" is thrown before any
+ * response is received, so the POST body was never delivered. Any other
+ * failure (including one after a response came back, e.g. a body-parsing
+ * error) is rethrown as-is rather than resending an already-delivered,
+ * non-idempotent message.
  */
 class RetryingHttpOutboundTransport extends DidCommHttpOutboundTransport {
   public async sendMessage(outboundPackage: Parameters<DidCommHttpOutboundTransport['sendMessage']>[0]) {
     try {
       return await super.sendMessage(outboundPackage)
-    } catch {
+    } catch (error) {
+      const cause = error instanceof Error ? error.cause : undefined
+      const causeMessage = cause instanceof Error ? cause.message : undefined
+      if (causeMessage !== 'Network request failed') {
+        throw error
+      }
       return await super.sendMessage(outboundPackage)
     }
   }

--- a/app/src/utils/bc-agent-modules.ts
+++ b/app/src/utils/bc-agent-modules.ts
@@ -127,7 +127,12 @@ export function getBCAgentModules({
       },
       mediationRecipient: {
         mediatorInvitationUrl: mediatorInvitationUrl,
-        mediatorPickupStrategy: DidCommMediatorPickupStrategy.Implicit,
+        // PickUpV2, matching the runtime start in configureMessagePickup. This
+        // said Implicit until 2026-08-31 — harmless here only because the runtime
+        // override happened to correct it, but it meant the declared config was a
+        // lie, and copying this block into a new agent (as the witness-server
+        // effectively had) produced an agent that could never receive anything.
+        mediatorPickupStrategy: DidCommMediatorPickupStrategy.PickUpV2,
         // Pickup V2 polling cadence (see configureMessagePickup): each poll is
         // a status-request the mediator answers from its queue, so delivery is
         // request/ack'd instead of live-pushed into a websocket that may have
@@ -151,6 +156,13 @@ export function getBCAgentModules({
         // at 1s that is ~86k mediator requests/day per idle wallet, which is
         // fine for demo/testing but wants an idle/active split before it
         // ships (see the parked adaptive-polling work).
+        //
+        // The witness-server carried this same bug on Implicit until 2026-08-31 and
+        // received nothing at all through the mediator — the wallet's runtime
+        // override is the ONLY reason this side was unaffected. Anything new that
+        // talks to this mediator must start pickup explicitly too; the reusable
+        // guard is startMediatorMessagePickup in @bifold/vrc-shared (src/mediation.ts),
+        // and the diagnosis is docs/spikes/e2e-vrc-connect-findings.md.
         //
         // Safe since the mediator pickup queue moved off askar to postgres on
         // 2026-08-26; before that a faster cadence tripped rate-correlated

--- a/app/src/utils/mediatorPickupStrategy.guard.test.ts
+++ b/app/src/utils/mediatorPickupStrategy.guard.test.ts
@@ -1,0 +1,144 @@
+/**
+ * App-side guard: no agent config here may use a mediator pickup strategy that
+ * cannot receive, and no call site may leave the strategy implicit.
+ *
+ * The twin of the bifold guard in
+ * `bifold/packages/witness-server/__tests__/unit/mediatorPickupStrategy.guard.test.ts`.
+ * Two guards rather than one because the two trees ship and test separately —
+ * bifold is a submodule consumed on its own, so a guard living only up here
+ * would not protect it, and one living only down there would not protect
+ * `app/src`.
+ *
+ * Why a scanning test and not just a shared constant: the failure is invisible.
+ * A push-only strategy (`Implicit`) against a mediator that queues rather than
+ * pushes sends every outbound message perfectly and receives NOTHING, with no
+ * error on either side — an agent that looks healthy and is deaf. A constant
+ * cannot stop the next agent typing `Implicit` in a new file, which is exactly
+ * how the witness-server ended up losing every inbound message.
+ * See docs/spikes/e2e-vrc-connect-findings.md ("fourth failure layer").
+ */
+import { readdirSync, readFileSync, statSync } from 'fs'
+import { join, relative, resolve } from 'path'
+
+/** Strategies that cannot reliably receive from a queueing mediator. */
+const UNRECEIVABLE = new Set(['Implicit', 'PickUpV2LiveMode', 'None'])
+
+/** The guard itself is allowed to name them. */
+const ALLOWED = ['utils/mediatorPickupStrategy.guard.test.ts']
+
+const SRC_ROOT = resolve(__dirname, '..')
+
+function sourceFiles(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules') continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      sourceFiles(full, found)
+    } else if (/\.tsx?$/.test(entry) && !entry.endsWith('.d.ts')) {
+      found.push(full)
+    }
+  }
+  return found
+}
+
+/**
+ * Strip comments and string literals, so prose that merely mentions
+ * `initiateMessagePickup()` — including the comments warning about this bug —
+ * is not flagged. Otherwise the fix is to add allowlist entries, which hollows
+ * the guard out.
+ */
+function stripCommentsAndStrings(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1 ')
+    .replace(/`(?:\\[\s\S]|[^\\`])*`/g, '``')
+    .replace(/'(?:\\.|[^\\'])*'/g, "''")
+    .replace(/"(?:\\.|[^\\"])*"/g, '""')
+}
+
+function scannedFiles(): Array<[string, string]> {
+  return sourceFiles(SRC_ROOT)
+    .map(
+      (file) =>
+        [relative(SRC_ROOT, file).replace(/\\/g, '/'), stripCommentsAndStrings(readFileSync(file, 'utf8'))] as [
+          string,
+          string
+        ]
+    )
+    .filter(([rel]) => !ALLOWED.includes(rel))
+}
+
+/** Arguments of each `initiateMessagePickup(...)` call, found by walking to the
+ *  matching close paren so multi-line calls are handled. */
+function pickupCallArgs(source: string): string[] {
+  const calls: string[] = []
+  const needle = 'initiateMessagePickup('
+  let index = source.indexOf(needle)
+  while (index !== -1) {
+    let depth = 0
+    let end = index + needle.length - 1
+    for (; end < source.length; end++) {
+      if (source[end] === '(') depth++
+      else if (source[end] === ')') {
+        depth--
+        if (depth === 0) break
+      }
+    }
+    calls.push(source.slice(index + needle.length, end))
+    index = source.indexOf(needle, end)
+  }
+  return calls
+}
+
+/** True when the argument list has a top-level comma — i.e. an explicit strategy. */
+function hasSecondArgument(args: string): boolean {
+  let depth = 0
+  for (const char of args) {
+    if ('([{'.includes(char)) depth++
+    else if (')]}'.includes(char)) depth--
+    else if (char === ',' && depth === 0) return true
+  }
+  return false
+}
+
+describe('mediator pickup strategy (app guard)', () => {
+  const files = scannedFiles()
+
+  it('scans a plausible number of source files', () => {
+    // Guards the guard: a broken path would make the assertions below pass
+    // vacuously, which is how a scanning test quietly rots into a no-op.
+    expect(files.length).toBeGreaterThan(50)
+  })
+
+  it('no agent config uses a strategy that cannot receive', () => {
+    const offenders: string[] = []
+
+    for (const [rel, source] of files) {
+      const pattern = /mediatorPickupStrategy:\s*([A-Za-z0-9_.'"$]+)/g
+      let match: RegExpExecArray | null
+      while ((match = pattern.exec(source)) !== null) {
+        const value = match[1].replace(/['"]/g, '')
+        const name = value.includes('.') ? value.split('.').pop() ?? value : value
+        if (UNRECEIVABLE.has(name)) {
+          offenders.push(`${rel}: mediatorPickupStrategy: ${value}`)
+        }
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+
+  it('every initiateMessagePickup call passes the strategy explicitly', () => {
+    const offenders: string[] = []
+
+    for (const [rel, source] of files) {
+      for (const args of pickupCallArgs(source)) {
+        if (!hasSecondArgument(args)) {
+          offenders.push(`${rel}: initiateMessagePickup(${args.trim().slice(0, 40)}) — no explicit strategy`)
+        }
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/docs/plans/openvtc-integration-plan/2026-09-01-bam.md
+++ b/docs/plans/openvtc-integration-plan/2026-09-01-bam.md
@@ -1,0 +1,93 @@
+# 2026-09-01 — Brendan and the agent
+
+Follow-up to the 2026-08-24 mediator regression entry (`2026-08-24-bam.md`) on
+`feat/trust-tasks-integration`: that entry root-caused and fixed the shared
+production mediator's forwarding strategy (`QueueOnly`) for the *wallet-to-wallet*
+path. It did not cover the witness-server, which turned out to have the
+matching half of the same class of bug, unfixed, the whole time.
+
+## Finding
+
+`yarn e2e:vrc:witnessed:android-only` (two physical Android phones, attended)
+failed 4/4 identically at `witness.waitForParticipants` — *"only 0/2
+participant(s) connected"*. Root cause: the witness-server's mediation-recipient
+config used `MediatorPickupStrategy.Implicit` — push-only, issues no pickup
+requests — against the same `QueueOnly` mediator the 08-24 fix targeted, which
+only queues and never pushes. The witness could send (mediation request,
+`keylist-update`, locality heartbeats) but received nothing, ever, with no
+error on either side. The wallet was moved onto explicit `PickUpV2` polling on
+2026-08-18 (`bc-agent-modules.ts`) specifically to fit this same mediator's
+`QueueOnly` behavior; the witness-server was never given the equivalent.
+
+Full diagnosis chain, the A/B evidence proving it (including that mediator
+mode itself is not the problem — a fresh wallet with the pull strategy fixed
+passed cleanly through the same mediator), and the "why did this look
+machine-specific" mechanism (a value persisted on a wallet's MediationRecord
+outranks module config) are in `docs/spikes/e2e-vrc-connect-findings.md`
+("fourth failure layer") — not duplicated here.
+
+## Decision: DIRECT is the primary architecture; MEDIATOR is a supported,
+now-tested fallback
+
+Both matter, for different reasons, and both are now proven working on real
+devices (see below):
+
+- **DIRECT** (the witness's own HTTP endpoint, tunneled for e2e) is lower
+  latency for the live ceremony — direct HTTP is synchronous; a mediated hop
+  costs up to a full `mediatorPollingInterval` each way — and keeps the
+  witness's traffic off the same shared mediator that already sees the two
+  wallets' own relationship, which matters for a system whose purpose is
+  attesting relationships. This is the recommended default.
+- **MEDIATOR** avoids the operational cost of a witness needing a stable,
+  publicly reachable endpoint (TLS, DNS, uptime) — real for an operator who
+  can't or won't expose a public port — and is a legitimate disaster-recovery
+  lever if a witness's direct endpoint has an outage: flipping to mediator
+  mode is one env var, not a cancelled event. That lever was dead the whole
+  time this bug existed; a fallback nobody tests is worse than no fallback.
+
+## Applied
+
+- `startMediatorMessagePickup` / `assertSupportedMediatorPickupStrategy` in
+  `@bifold/vrc-shared` (`src/mediation.ts`) — passes the pickup strategy
+  explicitly wherever a credo agent talks to a mediator, bypassing both module
+  config and any value persisted on the wallet's MediationRecord. Wired into
+  the witness-server, `vrc-reference/BaseAgent.ts`, `core/utils/agent.ts`, and
+  the app's foreground-resume path (`core/contexts/activity.tsx`, which was
+  separately leaking a duplicate polling loop on every resume — caught by the
+  same fix). A repo-wide static-analysis guard
+  (`mediatorPickupStrategy.guard.test.ts`, in both bifold and `app/`) fails the
+  build if any file declares an unreceivable strategy or omits an explicit one
+  on `initiateMessagePickup()`, so this class of bug can't reappear silently.
+- `e2e/lib/witness.js` no longer lets a developer's local, gitignored
+  `bifold/packages/witness-server/.env` decide the witnessed e2e's transport —
+  `MEDIATOR_INVITATION_URL` is passed explicitly by the harness (this was the
+  mechanism behind "works on my machine, not on Brendan's": Alberto's
+  `.env` has it commented out, so his witness only ever ran DIRECT and never
+  touched the broken path) — and the witness's own startup banner is read back
+  and asserted against what was requested.
+- **`yarn e2e:vrc:witnessed:android-only:mediator`** — a new, dedicated variant
+  that deliberately runs the witness in MEDIATOR mode (reusing `app/.env`'s own
+  `MEDIATOR_URL`, so it's a real test against production infrastructure), so
+  the fallback gets exercised on demand instead of only when someone remembers
+  to set an env var by hand. This is the direct fix for how the bug survived —
+  nothing had run this path before.
+
+**Confirmed on device (2026-09-01):** both `yarn e2e:vrc:witnessed:android-only`
+(DIRECT) and the new `:mediator` variant passed on the same two physical
+Android phones against the same production mediator — first run after the fix,
+both transports. Full run detail in the spike doc.
+
+## Still open
+
+- No `mediatorPollingInterval` set for the witness (credo's 5s default now
+  applies, where previously it polled not at all — new behavior, not a
+  regression, but worth measuring against the wallet's tuned 1s cadence).
+- No periodic/CI job runs the `:mediator` variant automatically — manual, on
+  demand, for now.
+
+## What this supersedes
+
+Nothing in the plan's prior text claimed the witness-server's mediator support
+was tested or working — it was simply never mentioned. This entry is the first
+record of the witness's transport architecture as a decision rather than an
+unstated default.

--- a/docs/plans/openvtc-integration-plan/trust_tasks_subtask.md
+++ b/docs/plans/openvtc-integration-plan/trust_tasks_subtask.md
@@ -932,26 +932,28 @@ legacy dual-accept path is true by construction, not yet e2e'd), step 4
 (credential-exchange with a VTA), step 1 (the `tsp-core` dependency
 direction — TSP-side), and the proof-set migration (parent §4.6, parked on
 the working group). Reasoning and evidence per day: the dated companions,
-latest [`2026-08-24-bam.md`](./2026-08-24-bam.md).
+latest [`2026-09-01-bam.md`](./2026-09-01-bam.md).
 
-**Regression (2026-08-24), root-caused and resolved — operational, not a
-wallet bug:** `yarn e2e:vrc:android-only` failed 4/4 against this exact
-commit — the peer's `didexchange/1.1/request` never reached the recipient's
-mediator mailbox. Root-caused two stacked operational issues on the shared
-production `credo-mediator`, neither a `keyring-wallet`/`bifold` code
-problem: (1) the deployed container was a **pre-credo-0.6 build** (`d9ff9cb`,
-2026-07-27) that predates the mediator repo's own `3a5ea51` migration, so its
-forward handler silently dropped every message; (2) after redeploying
-current `HEAD` (`375518d`), a second issue surfaced — the new image's
-*default* `messagePickup.forwardingStrategy` (`DirectDelivery`) only
-delivers to an already-open live session, which doesn't fit this wallet's
-deliberate polling-only (`PickUpV2`, non-live) pickup design. Fixed by
-setting `MESSAGE_PICKUP__FORWARDING_STRATEGY=QueueOnly`. Both fixes are live
-in production; `yarn e2e:vrc:android-only` now **passes clean** — both
-contacts visible, all trust-task ceremony markers present. Full diagnosis
-chain in [`2026-08-24-bam.md`](./2026-08-24-bam.md). "Complete for current
-wallets" above holds — the wallet/bifold protocol implementation was never
-the problem.
+**Mediator delivery.** The shared production `credo-mediator` must run a
+post-`3a5ea51` (credo-0.6+) build and
+`MESSAGE_PICKUP__FORWARDING_STRATEGY=QueueOnly` to match this wallet's
+deliberate polling-only (`PickUpV2`, non-live) pickup design — a pre-migration
+build silently drops every forwarded message, and the *default*
+`DirectDelivery` strategy only delivers to an already-open live session rather
+than queuing for pickup. `yarn e2e:vrc:android-only` passes clean against this
+configuration. Reasoning: [`2026-08-24-bam.md`](./2026-08-24-bam.md).
+
+**Witness transport.** The witness reaches participants over DIRECT HTTP by
+default — lower latency than a mediated round-trip, and it keeps the
+witness's traffic off the same shared mediator that already sees the two
+wallets' own relationship — or over the shared MEDIATOR as a supported
+fallback, for an operator who can't expose a public port or to recover from a
+direct-endpoint outage without cancelling a live event. Both transports are
+proven end-to-end: `yarn e2e:vrc:witnessed:android-only` (DIRECT) and
+`yarn e2e:vrc:witnessed:android-only:mediator` (MEDIATOR) — the latter exists
+specifically so the fallback keeps getting exercised rather than rotting
+silently between real uses. Reasoning:
+[`2026-09-01-bam.md`](./2026-09-01-bam.md).
 
 ### 1. Resolve review A1 — `tsp-core`'s dependency direction
 

--- a/docs/spikes/e2e-vrc-connect-findings.md
+++ b/docs/spikes/e2e-vrc-connect-findings.md
@@ -284,29 +284,52 @@ is not reachable from the mode observation alone.
 
 ### Remedies
 
-**Applied:** `startMediatorMessagePickup` / `assertSupportedMediatorPickupStrategy`
-in `@bifold/vrc-shared` (`src/mediation.ts`), called by the witness-server after
-`agent.initialize()`. It passes the strategy explicitly, which bypasses both the
-module config and any value pinned on the MediationRecord, and logs the effective
-strategy plus any pinned value it overrode. `vrc-reference/src/BaseAgent.ts` and
-`bifold/packages/core/src/utils/agent.ts` still declare `Implicit` and want the
-same treatment.
+**Applied, everywhere the codebase talks to a mediator:**
+- `startMediatorMessagePickup` / `assertSupportedMediatorPickupStrategy` in
+  `@bifold/vrc-shared` (`src/mediation.ts`) — passes the pickup strategy
+  explicitly, which bypasses both the module config and any value pinned on
+  the MediationRecord, and logs the effective strategy plus any pinned value
+  it overrode. Called by the witness-server (`WitnessService.ts`, after
+  `agent.initialize()`) and `vrc-reference/src/BaseAgent.ts`.
+  `bifold/packages/core/src/utils/agent.ts`'s module config now declares
+  `PickUpV2` directly (it has no runtime override of its own, unlike the app,
+  so the declared config is what consumers of `@bifold/core` actually get).
+  `core/src/contexts/activity.tsx`'s foreground-resume path now stops the
+  running pickup loop before restarting it with an explicit strategy — it had
+  been leaking a duplicate polling loop on every resume, doubling the wallet's
+  request rate against shared infrastructure for the life of the process; see
+  the `startMediatorMessagePickup` doc comment for where the same shape of bug
+  was caught a second time.
+- A repo-wide static-analysis guard,
+  `witness-server/__tests__/unit/mediatorPickupStrategy.guard.test.ts` and its
+  app-side twin `app/src/utils/mediatorPickupStrategy.guard.test.ts` — fails
+  the build if any file declares an unreceivable strategy, or calls
+  `initiateMessagePickup()` without one. A shared constant doesn't prevent the
+  next agent from typing `Implicit` in a new file (that's exactly how this
+  happened); the guard reads the source tree so it can't be bypassed by not
+  importing the helper.
+- The `WitnessService.test.ts` test that used to *document* `Implicit` as
+  intended behaviour with an `expect(true).toBe(true)` body now asserts the
+  actual contract (a pull strategy is required; push-only strategies throw
+  with an explanation) — prose enshrining the bug is gone.
+- `e2e/lib/witness.js` no longer lets a developer's `bifold/packages/witness-server/.env`
+  decide this run's transport: `MEDIATOR_INVITATION_URL` is passed explicitly
+  (forced empty → DIRECT, unless `WITNESS_MEDIATOR_INVITATION_URL` is set to
+  deliberately test mediator mode), and the witness's own startup banner is
+  read back and asserted against what was requested — a mismatch fails in
+  seconds with a clear message instead of as a mysterious participant-connect
+  timeout. The wallet is now genuinely temporary too: `VRC_WALLET_PATH` points
+  it into the same per-run temp dir as the invitation file (previously only
+  the invitation file was temporary; the wallet was a persistent, named
+  directory reused across every run — see "the part that made this look
+  machine-specific," above), so `stop()`'s existing cleanup removes it
+  automatically and no run can inherit another run's persisted mediation
+  state. `yarn fresh` is no longer relevant to the e2e path at all.
 
-**Open tuning question:** the witness sets no `mediatorPollingInterval`, so it now
+**Open tuning question:** the witness sets no `mediatorPollingInterval`, so it
 polls at credo's 5 s default — previously it polled not at all, so this is new
 behaviour rather than a regression, but each inbound hop of the witness ceremony
 now costs up to 5 s. The wallet deliberately runs 1 s (`bc-agent-modules.ts`, with
 the measured justification). Matching that would cut ceremony latency at the cost
 of load on shared infrastructure; it wants the same kind of measurement the wallet
-value got, not a guess.
-
-**Also worth fixing (not the cause, but what hid it):**
-- The witness's transport mode is decided by an untracked `.env`
-  (`MEDIATOR_INVITATION_URL`), which `e2e/lib/witness.js` cannot override even
-  though its header asserts DIRECT mode. Pass the variable explicitly from the
-  harness and assert the banner's `Transport:` line.
-- `e2e/lib/witness.js` claims "a fresh temp wallet per run"; only the invitation
-  file is temporary.
-- `witness-server/__tests__/unit/WitnessService.test.ts` had a test that
-  *documented* Implicit as intended behaviour with an `expect(true).toBe(true)`
-  body — prose enshrining the bug while asserting nothing.
+value got, not a guess. Left open deliberately.

--- a/docs/spikes/e2e-vrc-connect-findings.md
+++ b/docs/spikes/e2e-vrc-connect-findings.md
@@ -333,3 +333,54 @@ now costs up to 5 s. The wallet deliberately runs 1 s (`bc-agent-modules.ts`, wi
 the measured justification). Matching that would cut ceremony latency at the cost
 of load on shared infrastructure; it wants the same kind of measurement the wallet
 value got, not a guess. Left open deliberately.
+
+### Confirmed fixed on device (2026-09-01)
+
+`yarn e2e:vrc:witnessed:android-only`, two physical Android phones
+(SM_G986U1 / Android 13, SM_S936U / Android 16), against the same production
+mediator, with the applied fix and harness hardening above. First run after the
+fix: **passed**. Witness banner read `DIRECT (HTTP)` as requested (transport
+guard confirmed the override took effect); both phones got `🤝 NEW PARTICIPANT
+CONNECTED` / `✓ Sent witness-announcement` from the witness — the exact signal
+that was silent across all four pre-fix failures; both landed the **Witnessed**
+badge; one landed **Secure Exchange** too, the other tolerated a hardware
+verification warning (a pre-existing, documented tolerance for an aging
+attestation root — see `assertSecureExchangeBadge` in `e2e/lib/flows.js` —
+unrelated to this bug). This closes the fourth failure layer.
+
+## Environment gotchas that cost debugging time but are not code bugs
+
+Two more things burned real time this session, worth naming so a future
+session recognizes them immediately instead of re-diagnosing from scratch.
+
+**A phantom, root-owned listener can occupy the witness's default web port
+(9003) on some machines**, invisible to `lsof -tiTCP:9003` (returns nothing)
+but real per `ss -ltn` (shows `LISTEN`) and per an actual bind attempt (fails
+`EADDRINUSE`). Observed present even immediately after a full machine reboot,
+before any e2e process had run — so it is some other persistent
+service/listener on that particular machine, not anything this repo's tooling
+starts or can identify. Root cause not identified; out of scope to chase
+further here. Symptom if hit: the witness's full startup banner prints, then
+`Error: listen EADDRINUSE ... port: 9003` right at the end, ~15s in.
+**Fix:** `e2e/lib/witness.js`'s `assertPortFree` now bind-tests the port
+directly (not via `lsof`) before starting anything, and fails in under a
+second with a message naming the port and the `WITNESS_PORT`/`WITNESS_WEB_PORT`
+override — see the "Witness fails immediately with 'port N is already in
+use...'" entry in `e2e/README.md`'s Troubleshooting section. If you hit this,
+just pick different ports; don't spend time trying to find the offending
+process.
+
+**`e2e/debug-witness-connect.js` has no lock-screen preflight**, unlike the
+maintained witnessed runners (which got one in `90a7b62` — see
+`ensureLockScreenEnabled` in `e2e/lib/driver.js`). If the single phone it
+drives falls asleep mid-run (e.g. left unattended — it's meant to be
+unattended, that's the point of the script, but the phone still needs to stay
+awake), the app never receives the paste-invitation input at all and the
+script times out at `completeOnboarding` with a screen dump containing just
+the lock-screen clock (`mWakefulness=Dozing`, `isKeyguardShowing=true` via
+`adb shell dumpsys power` / `dumpsys activity activities`) — which reads
+exactly like a genuine onboarding-flow hang if you don't check the screen
+state first. It is a throwaway diagnostic script (README: "not part of the
+maintained suite"), so this wasn't fixed; just know to check `adb shell
+dumpsys power | grep mWakefulness` before assuming a `debug-witness-connect.js`
+timeout is a real bug.

--- a/docs/spikes/e2e-vrc-connect-findings.md
+++ b/docs/spikes/e2e-vrc-connect-findings.md
@@ -325,6 +325,14 @@ is not reachable from the mode observation alone.
   machine-specific," above), so `stop()`'s existing cleanup removes it
   automatically and no run can inherit another run's persisted mediation
   state. `yarn fresh` is no longer relevant to the e2e path at all.
+- **The mediator-mode fallback now has its own confirmable test**:
+  `yarn e2e:vrc:witnessed:android-only:mediator` (2026-09-01) runs the same
+  witnessed exchange with the witness deliberately put into MEDIATOR mode,
+  reusing `app/.env`'s own `MEDIATOR_URL` so it's a real test against actual
+  infrastructure rather than a stand-in. This is the direct answer to how this
+  bug survived: mediator mode was never exercised by anything, deterministic
+  or otherwise. See `e2e/README.md`, "Confirming the mediator-mode fallback."
+  No periodic/CI job runs it automatically yet — manual, on demand, for now.
 
 **Open tuning question:** the witness sets no `mediatorPollingInterval`, so it
 polls at credo's 5 s default — previously it polled not at all, so this is new

--- a/docs/spikes/e2e-vrc-connect-findings.md
+++ b/docs/spikes/e2e-vrc-connect-findings.md
@@ -191,3 +191,122 @@ second, divergent DID for the same counterparty (worth hardening separately).
   `IOS_DEVICE_NAME="iPhone 17 Pro"`. The `API36_S25_A` AVD refuses to launch the
   app ("Error type 3: Activity class does not exist") despite a clean install —
   environment quirk, avoid it for e2e.
+
+## Fourth failure layer: the witness never picks up its mail (2026-08-31, bam)
+
+Session context: `yarn e2e:vrc:witnessed:android-only` on `feat/trust-tasks-integration`,
+two physical Android phones, witness-server run by the e2e harness against the same
+production mediator. Failed 4/4 identically at
+`witness.waitForParticipants(2, 120000)` — *"only 0/2 participant(s) connected"* —
+including once fully attended with both phones unlocked, which rules out Doze.
+
+### Symptom
+
+Both wallets accepted the witness's reusable OOB invitation, created a connection
+record with `theirLabel: "e2e-witness"`, and sent their `didexchange/1.1/request`.
+The witness logged **nothing at all** afterwards — no connection-state-changed, no
+message-received, no problem-report — so the `state === 'completed'` gate in
+`WitnessService.registerMessageHandlers` never opened and no `witness-announcement`
+was ever sent. Meanwhile the witness's own outbound traffic worked throughout:
+mediation request, `keylist-update` (ACKed), locality heartbeats, WebSocket
+teardown at shutdown. Sending fine, receiving nothing, no error on either side.
+
+### Diagnosis
+
+The witness ran `MediatorPickupStrategy.Implicit`. Implicit is **push-only** — per
+credo's own doc comment it "consists simply on initiating a long-lived session to a
+mediator and wait for the messages to arrive automatically", and it issues no
+pickup requests at all. Our mediator queues rather than pushes (it has run
+`MESSAGE_PICKUP__FORWARDING_STRATEGY=QueueOnly` since the 2026-08-24 fix in
+`docs/plans/openvtc-integration-plan/2026-08-24-bam.md`, which was applied to make
+the *wallet-to-wallet* run pass). A push-only recipient against a queue-only
+mediator receives nothing, permanently.
+
+The wallet was moved off exactly this failure on 2026-08-18 (second layer, above)
+and now calls `initiateMessagePickup(undefined, PickUpV2)` at runtime in
+`useBCAgentSetup.ts`. The witness-server was never given the equivalent, so the
+08-24 mediator fix that made the wallet reliable is the same change that made the
+witness deaf.
+
+Evidence, from the witness's own verbose log across the whole failing run
+(13,194 lines): exactly **one** inbound message, a `keylist-update-response`
+returned on the HTTP response body of the witness's own POST — i.e. return-route,
+not mediator delivery — and **zero** message-pickup protocol messages of any kind.
+
+### Confirmed by A/B, one phone, unattended (`e2e/debug-witness-connect.js`)
+
+| Witness wallet | Transport | Strategy observed at runtime | pickup msgs | Result |
+|---|---|---|---|---|
+| persistent | MEDIATOR | `implicit` | 0 | FAIL 0/2 |
+| persistent | DIRECT | n/a | — | **PASS** |
+| persistent (mutated, see below) | MEDIATOR | `explicit v2` | 175 | **PASS** |
+| **fresh** | MEDIATOR | `implicit` | 0 | **FAIL 0/1** |
+
+The last row reproduces the original failure deterministically in ~5 minutes with
+one phone. The third row matters just as much: through the *same* mediator, with
+PickUpV2, `messagepickup/2.0/delivery` carried the phone's `didexchange/1.1/request`
+and `/complete`, the connection completed, and the announcement went out. **The
+mediator was never the problem** — it queues and delivers on request. The witness
+simply never asked.
+
+### The part that made this look machine-specific
+
+Setting `mediatorPickupStrategy` in module config is **not sufficient**. credo
+resolves it as `mediationRecord.pickupStrategy ?? moduleConfig.mediatorPickupStrategy`
+(`DidCommMediationRecipientApi.getPickupStrategyForMediator`): a value persisted on
+the MediationRecord **in the agent's wallet outranks the config**, and credo writes
+one there itself whenever the config leaves the strategy unset — which is what
+happens in DIRECT mode, where `mediationRecipient` is `undefined` but a leftover
+default-mediator record is still found and triggers feature discovery.
+
+So the effective strategy depends on hidden per-wallet state. A witness whose
+wallet ever got `PickUpV2` pinned works forever after and looks fine; a fresh
+wallet is dead on arrival. This is why the failure appeared to be
+environment-specific rather than a deterministic bug, and why it survived: the
+witness-server's own wallet is persistent (`.wallets/<name>-wallet/`, *not* the
+e2e's temp dir despite the harness comment), and `yarn fresh` cleans
+`${WITNESS_NAME}-wallet` — the wrong wallet unless `WITNESS_NAME` is exported to
+match the run.
+
+Observed live: running the DIRECT-mode probe silently pinned `PickUpV2` onto the
+e2e wallet's record, after which the very next MEDIATOR-mode run passed. Any
+"it works now" result on a reused witness wallet should be treated as suspect
+until confirmed on a fresh one.
+
+### Superseded position
+
+An earlier reading of this session's evidence was "the witness is silently in
+MEDIATOR mode when the harness assumes DIRECT, and mediator mode is broken". The
+mode confusion is real and worth fixing (below), but it is not the defect: mediator
+mode works fine with a pull strategy. Recording this because the narrower true
+cause — push-only pickup, plus a config value that loses to persisted wallet state —
+is not reachable from the mode observation alone.
+
+### Remedies
+
+**Applied:** `startMediatorMessagePickup` / `assertSupportedMediatorPickupStrategy`
+in `@bifold/vrc-shared` (`src/mediation.ts`), called by the witness-server after
+`agent.initialize()`. It passes the strategy explicitly, which bypasses both the
+module config and any value pinned on the MediationRecord, and logs the effective
+strategy plus any pinned value it overrode. `vrc-reference/src/BaseAgent.ts` and
+`bifold/packages/core/src/utils/agent.ts` still declare `Implicit` and want the
+same treatment.
+
+**Open tuning question:** the witness sets no `mediatorPollingInterval`, so it now
+polls at credo's 5 s default — previously it polled not at all, so this is new
+behaviour rather than a regression, but each inbound hop of the witness ceremony
+now costs up to 5 s. The wallet deliberately runs 1 s (`bc-agent-modules.ts`, with
+the measured justification). Matching that would cut ceremony latency at the cost
+of load on shared infrastructure; it wants the same kind of measurement the wallet
+value got, not a guess.
+
+**Also worth fixing (not the cause, but what hid it):**
+- The witness's transport mode is decided by an untracked `.env`
+  (`MEDIATOR_INVITATION_URL`), which `e2e/lib/witness.js` cannot override even
+  though its header asserts DIRECT mode. Pass the variable explicitly from the
+  harness and assert the banner's `Transport:` line.
+- `e2e/lib/witness.js` claims "a fresh temp wallet per run"; only the invitation
+  file is temporary.
+- `witness-server/__tests__/unit/WitnessService.test.ts` had a test that
+  *documented* Implicit as intended behaviour with an `expect(true).toBe(true)`
+  body — prose enshrining the bug while asserting nothing.

--- a/docs/spikes/e2e-vrc-connect-findings.md
+++ b/docs/spikes/e2e-vrc-connect-findings.md
@@ -325,14 +325,15 @@ is not reachable from the mode observation alone.
   machine-specific," above), so `stop()`'s existing cleanup removes it
   automatically and no run can inherit another run's persisted mediation
   state. `yarn fresh` is no longer relevant to the e2e path at all.
-- **The mediator-mode fallback now has its own confirmable test**:
-  `yarn e2e:vrc:witnessed:android-only:mediator` (2026-09-01) runs the same
-  witnessed exchange with the witness deliberately put into MEDIATOR mode,
-  reusing `app/.env`'s own `MEDIATOR_URL` so it's a real test against actual
-  infrastructure rather than a stand-in. This is the direct answer to how this
-  bug survived: mediator mode was never exercised by anything, deterministic
-  or otherwise. See `e2e/README.md`, "Confirming the mediator-mode fallback."
-  No periodic/CI job runs it automatically yet — manual, on demand, for now.
+- **The mediator-mode fallback now has its own confirmable test, and it's been
+  run and passed** (see below): `yarn e2e:vrc:witnessed:android-only:mediator`
+  (2026-09-01) runs the same witnessed exchange with the witness deliberately
+  put into MEDIATOR mode, reusing `app/.env`'s own `MEDIATOR_URL` so it's a
+  real test against actual infrastructure rather than a stand-in. This is the
+  direct answer to how this bug survived: mediator mode was never exercised by
+  anything, deterministic or otherwise. See `e2e/README.md`, "Confirming the
+  mediator-mode fallback." No periodic/CI job runs it automatically yet —
+  manual, on demand, for now.
 
 **Open tuning question:** the witness sets no `mediatorPollingInterval`, so it
 polls at credo's 5 s default — previously it polled not at all, so this is new
@@ -344,9 +345,11 @@ value got, not a guess. Left open deliberately.
 
 ### Confirmed fixed on device (2026-09-01)
 
-`yarn e2e:vrc:witnessed:android-only`, two physical Android phones
-(SM_G986U1 / Android 13, SM_S936U / Android 16), against the same production
-mediator, with the applied fix and harness hardening above. First run after the
+Same two physical Android phones (SM_G986U1 / Android 13, SM_S936U / Android
+16) for both runs below, against the same production mediator, with the
+applied fix and harness hardening above.
+
+**DIRECT mode** (`yarn e2e:vrc:witnessed:android-only`) — first run after the
 fix: **passed**. Witness banner read `DIRECT (HTTP)` as requested (transport
 guard confirmed the override took effect); both phones got `🤝 NEW PARTICIPANT
 CONNECTED` / `✓ Sent witness-announcement` from the witness — the exact signal
@@ -355,6 +358,20 @@ badge; one landed **Secure Exchange** too, the other tolerated a hardware
 verification warning (a pre-existing, documented tolerance for an aging
 attestation root — see `assertSecureExchangeBadge` in `e2e/lib/flows.js` —
 unrelated to this bug). This closes the fourth failure layer.
+
+**MEDIATOR mode** (`yarn e2e:vrc:witnessed:android-only:mediator`, the new
+confirmable-fallback variant) — first run: also **passed**. Witness banner
+read `MEDIATOR (WebSocket)` as requested; both phones again got `🤝 NEW
+PARTICIPANT CONNECTED` / `✓ Sent witness-announcement`, this time actually
+delivered through the shared production mediator instead of direct HTTP; same
+badge outcome as the DIRECT run (one full `Witnessed` + `Secure Exchange`, one
+`Witnessed` with the same pre-existing hardware-verification tolerance). This
+is the first time mediator-mode witnessing has been confirmed working end to
+end on real devices — it was silently, completely broken from 2026-08-24
+until this fix, and nothing had exercised it before this run.
+
+Both transport modes the witness supports are now proven working on real
+hardware, not just by unit test or code inspection.
 
 ## Environment gotchas that cost debugging time but are not code bugs
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -326,6 +326,21 @@ banners and authenticate on both phones. Override the witness's name with
 `WITNESS_NAME`, or its ports with `WITNESS_PORT`/`WITNESS_WEB_PORT`, if the
 defaults collide with something else running locally.
 
+**The run is deterministic regardless of your local
+`bifold/packages/witness-server/.env`.** That file is gitignored and
+per-developer, and can (harmlessly, for interactive/manual witness use) commit
+to a mediator or a different transport. The harness always overrides the
+witness's transport (`MEDIATOR_INVITATION_URL`, forced to DIRECT unless you set
+`WITNESS_MEDIATOR_INVITATION_URL` to deliberately test mediator mode) and gives
+it a genuinely fresh, isolated wallet per run (`VRC_WALLET_PATH` inside the
+run's own temp dir, torn down with everything else at the end) — so nothing in
+your `.env`, and no state left over from a previous run, can change what this
+run actually exercises. If the witness's observed transport ever doesn't match
+what was requested, the harness fails immediately with a clear error rather
+than a mysterious participant-connect timeout minutes later. See
+`docs/spikes/e2e-vrc-connect-findings.md` ("fourth failure layer") for the
+incident this closes.
+
 **Locality verification is disabled by default.** The harness launches the
 witness with `WITNESS_LOCALITY_REQUIRED=false`: Appium-driven phones can't
 produce a co-location (BLE proximity) proof, and with the check enforced the
@@ -362,8 +377,8 @@ Since the relationship exchange moved onto Trust Tasks (plan: `docs/plans/openvt
 - **The gates are log markers, read from Android's run-scoped logcat** (`adb logcat -c` at session start; iOS has no logcat, Android's log covers both directions): `assertTrustTaskExchangeMarkers` (discovery → propose → issue sent/stored → receipts), `assertWitnessCeremonyMarkers` (session → challenge → VP → VWC → outcome-evidence self-check), `assertWitnessShareMarkers` (witness-share sent → verified and stored → receipted), and on devices the hardware-evidence marker (`Evidence block added […]` — the run fails loudly if the exchange downgrades to unattested).
 - **UI gates:** `assertVrcReceived` (contact with the peer's name — the name comes from the R-Card), and `assertContactShields` (the **Witnessed** indicator, plus Secure Exchange on devices). `openContactDetail` handles both navigation shapes (Contacts row → chat → header `ContactMenu` → View Contact, or straight to Contact Details) and checks ContactDetails' *bare* testIDs (`WitnessSection`, `WitnessedBadge`, `SecureExchangeBadge` — no `com.ariesbifold:id/` prefix).
 - **Runners:** `yarn e2e:vrc:witnessed` — simulator + emulator, unattended, the full witnessed exchange with a local witness behind a cloudflared tunnel (run from repo root; `APPIUM_PORT=4750 WDA_LOCAL_PORT=8101 ANDROID_AVD=<your AVD> yarn e2e:vrc:witnessed` is the known-good invocation on a Mac with an iPhone simulator); `yarn e2e:vrc:witnessed:devices` — the attended real-device version (the demo path; see `docs/DEMO_RUNBOOK_WITNESSED_EXCHANGE.md`).
-- **Env that matters:** `APPIUM_PORT` (default 4723 — set another port if something else already listens there), `WDA_LOCAL_PORT` (iOS simulator WebDriverAgent; 8101 known good), `ANDROID_AVD` (default `Pixel_8_API_33`). The Android 16 / API 36 PIN-modal fix (`waitForKeyboardGone` in `enableHardwareAttestation`) is in place and unchanged by the v4 work.
-- **Known intermittents on simulators, not regressions:** one wallet occasionally misses the witness connection ("only 1/2 participants connected") or iOS never sends the didexchange request (the open "iOS no-send"); the witness agent init can hang under heavy machine load. Re-run. None has been seen on real devices so far.
+- **Env that matters:** `APPIUM_PORT` (default 4723 — set another port if something else already listens there), `WDA_LOCAL_PORT` (iOS simulator WebDriverAgent; 8101 known good), `ANDROID_AVD` (default `Pixel_8_API_33`), `WITNESS_MEDIATOR_INVITATION_URL` (unset by default, forcing the witness into DIRECT mode regardless of local `.env` — set it to deliberately test mediator mode instead). The Android 16 / API 36 PIN-modal fix (`waitForKeyboardGone` in `enableHardwareAttestation`) is in place and unchanged by the v4 work.
+- **Known intermittents on simulators, not regressions:** one wallet occasionally misses the witness connection ("only 1/2 participants connected") or iOS never sends the didexchange request (the open "iOS no-send"); the witness agent init can hang under heavy machine load. Re-run. Distinct from a **deterministic 0/N** failure, seen on real devices through 2026-08-31: the witness silently running in mediator mode with a push-only pickup strategy against a mediator that only queues — fixed (see `docs/spikes/e2e-vrc-connect-findings.md`, "fourth failure layer"), and the harness no longer lets a local `.env` put the witness back into that mode by accident.
 - **Between runs:** free ports 4750/9002/9003 and kill stray `cloudflared`; cold-reboot an emulator that has been up for hours (its host network path degrades).
 
 ## Troubleshooting
@@ -374,6 +389,16 @@ Since the relationship exchange moved onto Trust Tasks (plan: `docs/plans/openvt
   device or biometrics needed, so it cheaply isolates witness connectivity from
   the rest of the witnessed flow. Diagnostic tool only — not part of the
   maintained suite.
+- **Witness fails immediately with "port N is already in use by another
+  process on this machine (not one this harness started or can
+  identify/kill…)"**: something outside the harness's control already holds
+  `WITNESS_PORT`/`WITNESS_WEB_PORT` (default 9002/9003) — possibly invisible
+  to `lsof` (e.g. a process this user can't enumerate; `ss -ltn` will still
+  show it LISTENing). Pick different ports:
+  `WITNESS_PORT=9202 WITNESS_WEB_PORT=9203 yarn e2e:vrc:witnessed:android-only`.
+  This check runs before the tunnel or witness process even start, specifically
+  so this shows up in seconds instead of as a confusing `EADDRINUSE` stack
+  trace at the bottom of the witness's full startup banner ~15s in.
 - **Real device: "Unable to launch WebDriverAgent … xcodebuild failed with
   code 65"**: WDA has never been provisioned for the team on this machine
   (appium doesn't pass `-allowProvisioningUpdates`). Prime it once:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -16,12 +16,14 @@ this folder is a small standalone npm package.
 | `yarn e2e:smoke` | Single device: install → onboarding → main tabs | No |
 | `yarn e2e:vrc:witnessed:devices` | Witnessed + hardware-attested exchange on a **physical Android phone + iPhone**, routed through a locally-run witness server — both wallets end up with a Verifiable Witness Credential (VWC) in addition to the peer VRC | **Yes** |
 | `yarn e2e:vrc:witnessed:android-only` | Same witnessed + attested exchange on **two physical Android phones** (no macOS/Xcode needed; two *physical* phones are required — emulators can't do hardware attestation) | **Yes** |
+| `yarn e2e:vrc:witnessed:android-only:mediator` | Same as above, but the witness runs in **MEDIATOR mode** (through the shared production mediator) instead of the default DIRECT mode — confirms the mediator-mode fallback still works, on demand, without hand-setting an env var. See "Confirming the mediator-mode fallback" below. | **Yes** |
 
 The same scripts exist inside this folder as `npm run vrc-exchange`,
 `vrc-exchange:android-only`, `vrc-exchange:devices`,
 `vrc-exchange:devices:android-only`, `store-migration`,
 `store-migration:android-only`, `onboarding-smoke`,
-`vrc-exchange:witnessed:devices`, `vrc-exchange:witnessed:android-only`.
+`vrc-exchange:witnessed:devices`, `vrc-exchange:witnessed:android-only`,
+`vrc-exchange:witnessed:android-only:mediator`.
 
 Every script above ends by printing a bordered pass/fail banner
 (`lib/banner.js`) so a completed run is easy to spot when scrolled back
@@ -368,6 +370,35 @@ adb devices                                      # list connected serials
 ANDROID_UDID=<phone-a-serial> ANDROID_UDID2=<phone-b-serial> \
   yarn e2e:vrc:witnessed:android-only
 ```
+
+### Confirming the mediator-mode fallback (`yarn e2e:vrc:witnessed:android-only:mediator`)
+
+DIRECT (the default above) is the recommended architecture for a live
+witnessing ceremony — lower latency, and it keeps the witness's traffic off
+the same shared mediator that already sees the two wallets' own relationship
+(see `docs/plans/openvtc-integration-plan/trust_tasks_subtask.md` for why that
+matters). But a witness operator who can't or doesn't want to expose a public
+port needs MEDIATOR mode to actually work as a fallback — and it silently
+didn't, for over a week, because nothing exercised that path (see
+`docs/spikes/e2e-vrc-connect-findings.md`, "fourth failure layer"). This
+variant runs the exact same witnessed exchange with the witness deliberately
+put into MEDIATOR mode, so that fallback gets confirmed on demand instead of
+rotting unnoticed again.
+
+Same devices, same attended flow, same everything as
+`yarn e2e:vrc:witnessed:android-only` — the only difference is the witness's
+transport. It reuses `app/.env`'s own `MEDIATOR_URL` as the witness's mediator
+invitation (same production mediator the wallets already connect to, so this
+is a real test of the actual fallback, not a stand-in); override with
+`WITNESS_MEDIATOR_INVITATION_URL` if you need a different one. Fails fast,
+before touching any device, if neither is available.
+
+There's no periodic/CI job running this automatically yet — it's a manual
+confirmation step for now. Worth doing after any change to mediation setup
+(`@bifold/vrc-shared` `src/mediation.ts`, `WitnessService.ts`'s
+`mediationRecipient` config, or the app's own `configureMessagePickup`), and
+periodically otherwise so this doesn't silently break again between real
+uses of the fallback.
 
 ## The Trust Task dialect (v4) — what the runs assert now
 

--- a/e2e/lib/config.js
+++ b/e2e/lib/config.js
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -6,6 +7,30 @@ const repoRoot = path.resolve(
   "..",
   ".."
 );
+
+/**
+ * The witness's mediator invitation for the ":mediator" e2e variant (see
+ * run-vrc-exchange-witnessed-android-only-devices-mediator.js). Reuses
+ * app/.env's own MEDIATOR_URL rather than requiring a second, separately
+ * maintained value: it's the same production mediator the wallets already
+ * connect to, so this is what makes the variant a real test of "does
+ * mediator-mode witnessing work against our actual infrastructure" rather
+ * than a stand-in. Set WITNESS_MEDIATOR_INVITATION_URL to override.
+ */
+export function resolveWitnessMediatorInvitationUrl() {
+  if (process.env.WITNESS_MEDIATOR_INVITATION_URL) {
+    return process.env.WITNESS_MEDIATOR_INVITATION_URL;
+  }
+  const appEnvPath = path.join(repoRoot, "app", ".env");
+  if (existsSync(appEnvPath)) {
+    const match = readFileSync(appEnvPath, "utf-8").match(/^MEDIATOR_URL=(.+)$/m);
+    if (match) return match[1].trim();
+  }
+  throw new Error(
+    "no mediator invitation URL to run the witness against — set WITNESS_MEDIATOR_INVITATION_URL, " +
+      "or set MEDIATOR_URL in app/.env (reused as-is: same production mediator the wallets already use)."
+  );
+}
 
 export const APP_ID = "asml.bkc.harvard.wallet";
 export const TEST_ID_PREFIX = "com.ariesbifold:id/";

--- a/e2e/lib/flows.js
+++ b/e2e/lib/flows.js
@@ -662,7 +662,10 @@ export async function returnToContacts(driver) {
  */
 export async function openContactDetail(driver, peerName) {
   // Already on the peer's chat? (header menu present + peer name visible)
-  if (!(await existsTestId(driver, "ContactMenu", 2000))) {
+  const alreadyOnPeerChat =
+    (await existsTestId(driver, "ContactMenu", 2000)) &&
+    (await byTextContains(driver, peerName).isExisting());
+  if (!alreadyOnPeerChat) {
     let onTab = false;
     for (let backs = 0; backs < 3 && !onTab; backs++) {
       if (await existsTestId(driver, "Contacts", 3000)) {
@@ -1042,4 +1045,24 @@ export async function acceptRelationshipProposalIfPrompted(driver, timeout = 900
   }
   console.log(`[e2e] ${driver.e2ePlatform}: no proposal prompt (peer side proposed)`);
   return false;
+}
+
+/**
+ * Run acceptRelationshipProposalIfPrompted on both sides of an exchange and
+ * assert that at least one of them actually saw the proposal. If discovery
+ * failed and neither side was ever prompted, both calls return false and the
+ * run would otherwise fall through into assertVrcReceived's generic
+ * "contact never appeared" timeout — fail loudly here instead, with the
+ * specific cause.
+ */
+export async function acceptRelationshipProposalOnEitherSide(driverA, driverB, timeout = 90000) {
+  const [acceptedA, acceptedB] = await Promise.all([
+    acceptRelationshipProposalIfPrompted(driverA, timeout),
+    acceptRelationshipProposalIfPrompted(driverB, timeout),
+  ]);
+  if (!acceptedA && !acceptedB) {
+    throw new Error(
+      `${driverA.e2ePlatform}/${driverB.e2ePlatform}: neither side saw a relationship proposal prompt within ${timeout}ms — discovery likely failed`
+    );
+  }
 }

--- a/e2e/lib/flows.js
+++ b/e2e/lib/flows.js
@@ -765,6 +765,80 @@ export async function assertContactShields(driver, peerName, timeout = 240000, o
 }
 
 /**
+ * ContactDetails renders SecureExchangeBadge only on a fully-validated chain
+ * — a warning outcome (evidence present, chain didn't validate — e.g. an
+ * aging attestation root, see docs/HARDWARE_ATTESTATION_FLOW.md "Known
+ * limitations" #5) omits the badge exactly like no evidence at all (see
+ * assertContactShields' comment). The old per-credential-offer screen used
+ * to distinguish the two via its own AttestationWarning banner; v4's
+ * automatic flow has no chat-screen equivalent, so Android's own
+ * verification log is the only remaining signal. No equivalent surfaces on
+ * iOS — this is a no-op there, same as assertTrustTaskExchangeMarkers.
+ */
+async function androidSawAttestationAttempt(driver) {
+  if (driver.e2ePlatform !== "android" || !driver.e2eUdid) return false;
+  try {
+    const { execSync } = await import("node:child_process");
+    const log = execSync(`adb -s ${driver.e2eUdid} logcat -d -s ReactNativeJS:*`, {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return /\[VRC:Verify\]|\[VRC:Badge\]/.test(log);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Assert the "Secure Exchange" badge (peer device-attestation, re-validated
+ * on-device) landed for the peer — attestation shield only, no witness
+ * involved. For the plain (non-witnessed) real-device VRC exchange, where
+ * assertContactShields' witness requirement can never be satisfied.
+ *
+ * options.requireSecureExchange (default true): pass false to tolerate the
+ * warning outcome unconditionally instead of falling back to the Android
+ * log check below (e.g. when the caller already knows the peer's evidence
+ * was attempted through some other signal).
+ */
+export async function assertSecureExchangeBadge(driver, peerName, timeout = 120000, options = {}) {
+  const requireSecureExchange = options.requireSecureExchange ?? true;
+  const deadline = Date.now() + timeout;
+  let sawAttestation = false;
+  while (Date.now() < deadline) {
+    await openContactDetail(driver, peerName);
+    sawAttestation =
+      (await existsTestId(driver, "SecureExchangeBadge", 3000)) ||
+      (await existsRawId(driver, "SecureExchangeBadge", 2000)) ||
+      (await byTextContains(driver, "Secure Exchange").isExisting());
+    if (sawAttestation || !requireSecureExchange) {
+      console.log(
+        `[e2e] ${driver.e2ePlatform}: "${peerName}" shows` +
+          (sawAttestation
+            ? " Secure Exchange"
+            : " no Secure Exchange badge (not required — hardware verification warning accepted)")
+      );
+      return;
+    }
+    if (await existsTestId(driver, "BackButton", 2000)) {
+      await tapTestId(driver, "BackButton");
+    }
+    await sleep(3000);
+  }
+  // Badge never rendered — tell "evidence never attempted" (real failure)
+  // apart from "attempted, chain didn't validate" (tolerated) via Android's
+  // own verification log before failing the run.
+  if (await androidSawAttestationAttempt(driver)) {
+    console.log(
+      `[e2e] ${driver.e2ePlatform}: ⚠️ no Secure Exchange badge for "${peerName}", but the verification log ` +
+        `shows evidence was attempted (commonly an aging/legacy attestation root, not a flow regression); continuing`
+    );
+    return;
+  }
+  await screenshot(driver, "secure-exchange-missing");
+  throw new Error(`${driver.e2ePlatform}: "${peerName}" missing Secure Exchange badge after ${timeout}ms`);
+}
+
+/**
  * Assert a Verifiable Witness Credential (VWC) landed for the peer (witness
  * shield only). Kept for witness-focused checks; the full run uses
  * assertContactShields to require BOTH shields together.
@@ -801,6 +875,9 @@ export async function assertVrcReceived(driver, peerName, timeout = 120000) {
       onTab = true;
       break;
     }
+    // Real devices only: the signed delivery that follows consent may still
+    // be in flight here, requesting biometric confirmation. No-op elsewhere.
+    await handleBiometricConfirmIfPresent(driver);
     await unlockIfLocked(driver);
     if (await existsTestId(driver, "BackButton", 2000)) {
       await tapTestId(driver, "BackButton");
@@ -815,6 +892,7 @@ export async function assertVrcReceived(driver, peerName, timeout = 120000) {
       );
       return;
     }
+    await handleBiometricConfirmIfPresent(driver);
     await unlockIfLocked(driver);
     await sleep(3000);
   }
@@ -955,6 +1033,10 @@ export async function acceptRelationshipProposalIfPrompted(driver, timeout = 900
       console.log(`[e2e] ${driver.e2ePlatform}: relationship proposal accepted`);
       return true;
     }
+    // Real devices only: signing may request biometric confirmation while
+    // we're still waiting for the proposal prompt (e.g. the peer proposed
+    // and is already issuing). No-op on emulators/simulators.
+    await handleBiometricConfirmIfPresent(driver);
     await unlockIfLocked(driver);
     await sleep(2000);
   }

--- a/e2e/lib/witness.js
+++ b/e2e/lib/witness.js
@@ -1,8 +1,13 @@
 // Witness-server lifecycle for the witnessed VRC exchange e2e.
 //
 // Spawns bifold/packages/witness-server (ts-node) with a fresh temp wallet +
-// invitation per run, waits for its "READY" banner, reads the persisted
-// invitation URL, and tears it down. See e2e/README.md for usage.
+// invitation per run (VRC_WALLET_PATH points the wallet itself into the same
+// per-run temp dir as the invitation file, so both are wiped together by
+// stop() — no separate `yarn fresh` needed, and no run can inherit another
+// run's persisted mediation state; see docs/spikes/e2e-vrc-connect-findings.md
+// "the part that made this look machine-specific"), waits for its "READY"
+// banner, reads the persisted invitation URL, and tears it down. See
+// e2e/README.md for usage.
 import { spawn, execSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { createServer } from "node:net";
@@ -181,6 +186,23 @@ export async function startWitness({
       WITNESS_PUBLIC_URL: publicUrl,
       WITNESS_INVITATION_FILE: invitationFile,
       WITNESS_VERBOSE: process.env.WITNESS_VERBOSE || "false",
+      // Wallet lives in the per-run temp dir — see the file header. Also makes
+      // this run immune to `bifold/packages/witness-server/.env`'s own wallet
+      // location, if it sets one.
+      VRC_WALLET_PATH: join(dir, "wallets"),
+      // DIRECT mode by default, regardless of what a developer's local
+      // bifold/packages/witness-server/.env has committed to
+      // MEDIATOR_INVITATION_URL. That file is gitignored and per-developer, and
+      // dotenv (`import 'dotenv/config'` in witness-server/src/index.ts) never
+      // overrides a variable already present in the environment — so without
+      // this line, an uncommented MEDIATOR_INVITATION_URL there silently
+      // switches this run's transport out from under it. This is the exact
+      // divergence that made "works on my machine" true for one developer and
+      // false for another: see docs/spikes/e2e-vrc-connect-findings.md ("why
+      // Alberto"). Explicit empty string by default (not just omission, so it
+      // can't be inherited from the calling shell's own environment either);
+      // set WITNESS_MEDIATOR_INVITATION_URL to deliberately test mediator mode.
+      MEDIATOR_INVITATION_URL: process.env.WITNESS_MEDIATOR_INVITATION_URL || "",
       // Disable the co-location (BLE proximity) requirement: the witness
       // otherwise rejects the VP with a "locality-verification" error and the
       // exchange auto-falls back to a plain UNwitnessed VRC (no VWC / witness
@@ -196,6 +218,11 @@ export async function startWitness({
   // authoritative "a wallet connected" signal (the app shows no banner on
   // connect; witness participation only surfaces as a VWC after an exchange).
   let participantConnections = 0;
+  // The banner's own report of what it actually started as — read back below
+  // to confirm the MEDIATOR_INVITATION_URL override above took effect, instead
+  // of assuming it did. A silent transport mismatch is exactly the bug this
+  // harness spent a day chasing (docs/spikes/e2e-vrc-connect-findings.md).
+  let observedTransport;
   const onData = (buf) => {
     const s = buf.toString();
     // Surface witness lines (prefixed) so a stuck run is diagnosable
@@ -206,6 +233,8 @@ export async function startWitness({
     // "✓ Sent witness-announcement" fires once per completed participant
     const sent = s.match(/Sent witness-announcement/g);
     if (sent) participantConnections += sent.length;
+    const transportMatch = s.match(/Transport:\s+(DIRECT \(HTTP\)|MEDIATOR \(WebSocket\))/);
+    if (transportMatch) observedTransport = transportMatch[1];
   };
   proc.stdout.on("data", onData);
   proc.stderr.on("data", onData);
@@ -267,7 +296,27 @@ export async function startWitness({
     if (existsSync(invitationFile)) {
       const { invitationUrl } = JSON.parse(readFileSync(invitationFile, "utf-8"));
       if (invitationUrl) {
-        console.log(`[e2e] witness ready${readyLogged ? "" : " (invitation file present)"} — invitation captured`);
+        // Confirm the transport we asked for (via MEDIATOR_INVITATION_URL above)
+        // is the transport that actually started, from the witness's own banner —
+        // not assumed. Fail loudly here, in seconds, rather than as a mysterious
+        // participant-connect timeout 2+ minutes into an attended device run.
+        const expectMediator = Boolean(process.env.WITNESS_MEDIATOR_INVITATION_URL);
+        const expectedTransport = expectMediator ? "MEDIATOR (WebSocket)" : "DIRECT (HTTP)";
+        if (observedTransport && observedTransport !== expectedTransport) {
+          await stop();
+          throw new Error(
+            `witness started in ${observedTransport} mode, expected ${expectedTransport} ` +
+              `(requested via MEDIATOR_INVITATION_URL=${JSON.stringify(
+                process.env.WITNESS_MEDIATOR_INVITATION_URL || ""
+              )}). This should be impossible — the harness sets MEDIATOR_INVITATION_URL ` +
+              `explicitly precisely so a local .env can't override it; if this fires, something ` +
+              `upstream of that env var changed. See docs/spikes/e2e-vrc-connect-findings.md.`
+          );
+        }
+        console.log(
+          `[e2e] witness ready${readyLogged ? "" : " (invitation file present)"} — invitation captured` +
+            (observedTransport ? ` (${observedTransport})` : "")
+        );
         return { invitationUrl, publicUrl, name, stop, waitForParticipants };
       }
     }

--- a/e2e/lib/witness.js
+++ b/e2e/lib/witness.js
@@ -5,6 +5,7 @@
 // invitation URL, and tears it down. See e2e/README.md for usage.
 import { spawn, execSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -14,6 +15,37 @@ import { sleep } from "./driver.js";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const witnessDir = join(repoRoot, "bifold", "packages", "witness-server");
+
+/**
+ * Authoritative "is this port actually free" check via a real bind attempt.
+ * `lsof`-based freeing (below) can miss a listener it has no permission to
+ * enumerate — e.g. a root-owned process — in which case `lsof -tiTCP:<port>`
+ * silently returns nothing even though the port is occupied, and the witness
+ * only finds out ~15s later via a raw EADDRINUSE stack trace at the bottom of
+ * its full startup banner. Bind-testing here fails fast, before the tunnel
+ * and witness process even start, with a message that names the actual port
+ * and how to work around it.
+ */
+async function assertPortFree(port) {
+  await new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", (err) => {
+      if (err.code === "EADDRINUSE") {
+        reject(
+          new Error(
+            `port ${port} is already in use by another process on this machine (not one this harness ` +
+              `started or can identify/kill — e.g. \`lsof -tiTCP:${port}\` may show nothing even though ` +
+              `\`ss -ltn\` shows it LISTENing, which happens for a process this user can't enumerate). ` +
+              `Set WITNESS_PORT/WITNESS_WEB_PORT to an unused port and retry.`
+          )
+        );
+      } else {
+        reject(err);
+      }
+    });
+    srv.listen(port, () => srv.close(() => resolve()));
+  });
+}
 
 /**
  * Start a cloudflared quick tunnel to a local port and return its public
@@ -96,7 +128,8 @@ export async function startWitness({
   readyTimeoutMs = 180000,
 } = {}) {
   // Free the ports first — a prior run's witness whose shutdown hung would
-  // otherwise EADDRINUSE this one.
+  // otherwise EADDRINUSE this one. Best-effort: only catches processes this
+  // user can see/kill via lsof (see assertPortFree below for the case it can't).
   for (const p of [port, webPort]) {
     try {
       const pids = execSync(`lsof -tiTCP:${p} -sTCP:LISTEN`).toString().trim();
@@ -105,8 +138,16 @@ export async function startWitness({
         console.log(`[e2e] freed leftover process on :${p}`);
       }
     } catch {
-      /* nothing listening — good */
+      /* nothing listening (visible to lsof) — good */
     }
+  }
+
+  // Verify both ports actually ended up free — authoritative, unlike the
+  // lsof-based freeing above — and fail fast with a clear, actionable error
+  // instead of a confusing EADDRINUSE stack trace after the witness has
+  // already spent ~15s spinning up its agent and printing its full banner.
+  for (const p of [port, webPort]) {
+    await assertPortFree(p);
   }
 
   // Bring up the HTTPS tunnel to the witness's inbound port first, so its

--- a/e2e/lib/witnessedExchangeFlow.js
+++ b/e2e/lib/witnessedExchangeFlow.js
@@ -18,7 +18,7 @@ import net from "node:net";
 import { ensureAppium, stopAppium, screenshot, dumpSource, sleep } from "./driver.js";
 import {
   acceptInvitationViaPaste,
-  acceptRelationshipProposalIfPrompted,
+  acceptRelationshipProposalOnEitherSide,
   assertTrustTaskExchangeMarkers,
   assertVrcReceived,
   assertContactShields,
@@ -196,10 +196,7 @@ export async function runWitnessedExchange({
       "\n[e2e] OPERATOR: a relationship proposal appears on one phone (auto-accepted);\n" +
         "[e2e] OPERATOR: then satisfy the BIOMETRIC prompt on EACH phone when it appears.\n"
     );
-    await Promise.all([
-      acceptRelationshipProposalIfPrompted(sessionA),
-      acceptRelationshipProposalIfPrompted(sessionB),
-    ]);
+    await acceptRelationshipProposalOnEitherSide(sessionA, sessionB);
 
     await Promise.all([
       assertVrcReceived(sessionA, `${IDENTITY_B.firstName} ${IDENTITY_B.lastName}`),

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -14,6 +14,7 @@
     "onboarding-smoke": "node run-onboarding-smoke.js",
     "vrc-exchange:witnessed:devices": "node run-vrc-exchange-witnessed-devices.js",
     "vrc-exchange:witnessed:android-only": "node run-vrc-exchange-witnessed-android-only-devices.js",
+    "vrc-exchange:witnessed:android-only:mediator": "node run-vrc-exchange-witnessed-android-only-devices-mediator.js",
     "vrc-exchange:witnessed": "node run-vrc-exchange-witnessed.js"
   },
   "dependencies": {

--- a/e2e/run-vrc-exchange-devices-android-only.js
+++ b/e2e/run-vrc-exchange-devices-android-only.js
@@ -36,8 +36,10 @@ import {
   sleep,
 } from "./lib/driver.js";
 import {
-  acceptCredentialOfferFromChat,
   acceptInvitationViaPaste,
+  acceptRelationshipProposalIfPrompted,
+  assertSecureExchangeBadge,
+  assertTrustTaskExchangeMarkers,
   assertVrcReceived,
   completeOnboarding,
   enableHardwareAttestation,
@@ -179,8 +181,9 @@ try {
 
   console.log(
     "\n[e2e] ATTENDED RUN — keep both phones unlocked and within reach.\n" +
-      "[e2e] You will be asked to authenticate (biometric or device PIN) when\n" +
-      "[e2e] the OPERATOR banner appears in this console.\n"
+      "[e2e] A relationship proposal appears on one phone (auto-accepted); then\n" +
+      "[e2e] satisfy the BIOMETRIC prompt on EACH phone when the OPERATOR banner\n" +
+      "[e2e] appears in this console.\n"
   );
 
   android = await createSession("android", androidDeviceCaps(udidA));
@@ -201,18 +204,30 @@ try {
   const invitationUrl = await showRelationshipInvitation(android);
   await acceptInvitationViaPaste(android2, invitationUrl);
 
-  // Bidirectional exchange. expectAttestation makes each receiver REQUIRE the
-  // Secure Exchange banner (peer evidence chain-validated on-device).
-  // Longer timeout than emulators: two hardware signings + human auth in the loop.
+  // v4 consent: one bottom-sheet on the non-proposer wallet, no per-credential
+  // offers — both signed VRCs then flow automatically as trust tasks. The
+  // biometric prompts fire during the signed delivery that follows consent.
   await Promise.all([
-    acceptCredentialOfferFromChat(android, 600000, { expectAttestation: true }),
-    acceptCredentialOfferFromChat(android2, 600000, { expectAttestation: true }),
+    acceptRelationshipProposalIfPrompted(android),
+    acceptRelationshipProposalIfPrompted(android2),
   ]);
 
   await Promise.all([
     assertVrcReceived(android, `${IDENTITY_B.firstName} ${IDENTITY_B.lastName}`),
     assertVrcReceived(android2, `${IDENTITY_A.firstName} ${IDENTITY_A.lastName}`),
   ]);
+
+  // The crypto gates, from Android's run-scoped logcat (covers both directions).
+  await Promise.all([
+    assertTrustTaskExchangeMarkers(android),
+    assertTrustTaskExchangeMarkers(android2),
+  ]);
+
+  // Each receiver REQUIRES the Secure Exchange badge (peer evidence
+  // chain-validated on-device) — the device-attestation gate this test exists
+  // to prove.
+  await assertSecureExchangeBadge(android, `${IDENTITY_B.firstName} ${IDENTITY_B.lastName}`);
+  await assertSecureExchangeBadge(android2, `${IDENTITY_A.firstName} ${IDENTITY_A.lastName}`);
 
   printSuccess("vrc-exchange:devices:android-only");
   process.exitCode = 0;

--- a/e2e/run-vrc-exchange-devices-android-only.js
+++ b/e2e/run-vrc-exchange-devices-android-only.js
@@ -37,7 +37,7 @@ import {
 } from "./lib/driver.js";
 import {
   acceptInvitationViaPaste,
-  acceptRelationshipProposalIfPrompted,
+  acceptRelationshipProposalOnEitherSide,
   assertSecureExchangeBadge,
   assertTrustTaskExchangeMarkers,
   assertVrcReceived,
@@ -207,10 +207,7 @@ try {
   // v4 consent: one bottom-sheet on the non-proposer wallet, no per-credential
   // offers — both signed VRCs then flow automatically as trust tasks. The
   // biometric prompts fire during the signed delivery that follows consent.
-  await Promise.all([
-    acceptRelationshipProposalIfPrompted(android),
-    acceptRelationshipProposalIfPrompted(android2),
-  ]);
+  await acceptRelationshipProposalOnEitherSide(android, android2);
 
   await Promise.all([
     assertVrcReceived(android, `${IDENTITY_B.firstName} ${IDENTITY_B.lastName}`),

--- a/e2e/run-vrc-exchange-devices.js
+++ b/e2e/run-vrc-exchange-devices.js
@@ -36,8 +36,10 @@ import {
   sleep,
 } from "./lib/driver.js";
 import {
-  acceptCredentialOfferFromChat,
   acceptInvitationViaPaste,
+  acceptRelationshipProposalIfPrompted,
+  assertSecureExchangeBadge,
+  assertTrustTaskExchangeMarkers,
   assertVrcReceived,
   completeOnboarding,
   enableHardwareAttestation,
@@ -247,8 +249,9 @@ try {
 
   console.log(
     "\n[e2e] ATTENDED RUN — keep both phones unlocked and within reach.\n" +
-      "[e2e] You will be asked to authenticate (biometric or device PIN) when\n" +
-      "[e2e] the OPERATOR banner appears in this console.\n"
+      "[e2e] A relationship proposal appears on one phone (auto-accepted); then\n" +
+      "[e2e] satisfy the BIOMETRIC prompt on EACH phone when the OPERATOR banner\n" +
+      "[e2e] appears in this console.\n"
   );
 
   android = await createSession("android", androidDeviceCaps(androidUdid));
@@ -269,18 +272,31 @@ try {
   const invitationUrl = await showRelationshipInvitation(android);
   await acceptInvitationViaPaste(ios, invitationUrl);
 
-  // Bidirectional exchange. expectAttestation makes each receiver REQUIRE the
-  // Secure Exchange banner (peer evidence chain-validated on-device).
-  // Longer timeout than emulators: two hardware signings + human auth in the loop.
+  // v4 consent: one bottom-sheet on the non-proposer wallet, no per-credential
+  // offers — both signed VRCs then flow automatically as trust tasks. The
+  // biometric prompts fire during the signed delivery that follows consent.
   await Promise.all([
-    acceptCredentialOfferFromChat(android, 600000, { expectAttestation: true }),
-    acceptCredentialOfferFromChat(ios, 600000, { expectAttestation: true }),
+    acceptRelationshipProposalIfPrompted(android),
+    acceptRelationshipProposalIfPrompted(ios),
   ]);
 
   await Promise.all([
     assertVrcReceived(android, "Bob Baker"),
     assertVrcReceived(ios, "Alice Anderson"),
   ]);
+
+  // The crypto gates, from Android's run-scoped logcat (no-op on iOS —
+  // Android's log covers both directions of the exchange).
+  await Promise.all([
+    assertTrustTaskExchangeMarkers(android),
+    assertTrustTaskExchangeMarkers(ios),
+  ]);
+
+  // Each receiver REQUIRES the Secure Exchange badge (peer evidence
+  // chain-validated on-device) — the device-attestation gate this test exists
+  // to prove.
+  await assertSecureExchangeBadge(android, "Bob Baker");
+  await assertSecureExchangeBadge(ios, "Alice Anderson");
 
   printSuccess("vrc-exchange:devices");
   process.exitCode = 0;

--- a/e2e/run-vrc-exchange-devices.js
+++ b/e2e/run-vrc-exchange-devices.js
@@ -37,7 +37,7 @@ import {
 } from "./lib/driver.js";
 import {
   acceptInvitationViaPaste,
-  acceptRelationshipProposalIfPrompted,
+  acceptRelationshipProposalOnEitherSide,
   assertSecureExchangeBadge,
   assertTrustTaskExchangeMarkers,
   assertVrcReceived,
@@ -275,10 +275,7 @@ try {
   // v4 consent: one bottom-sheet on the non-proposer wallet, no per-credential
   // offers — both signed VRCs then flow automatically as trust tasks. The
   // biometric prompts fire during the signed delivery that follows consent.
-  await Promise.all([
-    acceptRelationshipProposalIfPrompted(android),
-    acceptRelationshipProposalIfPrompted(ios),
-  ]);
+  await acceptRelationshipProposalOnEitherSide(android, ios);
 
   await Promise.all([
     assertVrcReceived(android, "Bob Baker"),

--- a/e2e/run-vrc-exchange-witnessed-android-only-devices-mediator.js
+++ b/e2e/run-vrc-exchange-witnessed-android-only-devices-mediator.js
@@ -1,0 +1,108 @@
+/**
+ * WITNESSED two-wallet VRC exchange on REAL DEVICES (attended), Android-only,
+ * with the witness running in MEDIATOR mode instead of the default DIRECT.
+ *
+ * This is the ":mediator" twin of run-vrc-exchange-witnessed-android-only-devices.js
+ * — same flow, same devices, same everything, except the witness connects
+ * through the shared production mediator (WebSocket, message pickup) rather
+ * than over its own direct HTTP tunnel. It exists so mediator-mode witnessing
+ * gets exercised on demand instead of only when someone remembers to set
+ * WITNESS_MEDIATOR_INVITATION_URL by hand — that's exactly how the witness
+ * ended up silently unable to receive a single mediated message for over a
+ * week (see docs/spikes/e2e-vrc-connect-findings.md, "fourth failure layer").
+ *
+ * Two PHYSICAL phones are required, not emulators — see the DIRECT-mode
+ * runner's header for why.
+ *
+ * Usage:
+ *   node run-vrc-exchange-witnessed-android-only-devices-mediator.js
+ *   (or: yarn e2e:vrc:witnessed:android-only:mediator from repo root)
+ *
+ * Both phones connected over USB are auto-detected; if more or fewer than
+ * two are found, set ANDROID_UDID and ANDROID_UDID2 to pick them explicitly
+ * (`adb devices` lists connected serials). The mediator invitation defaults
+ * to app/.env's own MEDIATOR_URL; override with WITNESS_MEDIATOR_INVITATION_URL.
+ */
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+
+import { createSession } from "./lib/driver.js";
+import {
+  ANDROID_APK,
+  ANDROID_UDID,
+  ANDROID_UDID2,
+  androidDeviceCaps,
+  resolveWitnessMediatorInvitationUrl,
+} from "./lib/config.js";
+import { runWitnessedExchange, dumpAndroidWitnessLogs } from "./lib/witnessedExchangeFlow.js";
+
+// ---------- device discovery ----------
+
+/** Exactly two physical (non-emulator) android devices are required. */
+function detectTwoAndroidUdids() {
+  if (ANDROID_UDID && ANDROID_UDID2) return { a: ANDROID_UDID, b: ANDROID_UDID2 };
+  const out = execSync("adb devices").toString();
+  const physical = out
+    .split("\n")
+    .slice(1)
+    .map((l) => l.trim().split(/\s+/))
+    .filter(([id, state]) => id && state === "device" && !id.startsWith("emulator-"))
+    .map(([id]) => id);
+  if (physical.length !== 2) {
+    throw new Error(
+      `expected exactly two physical android devices (found: ${physical.join(", ") || "none"}). ` +
+        `Set ANDROID_UDID and ANDROID_UDID2 to pick them (see \`adb devices\`).`
+    );
+  }
+  return { a: physical[0], b: physical[1] };
+}
+
+function preflight() {
+  if (!existsSync(ANDROID_APK)) {
+    throw new Error(
+      `Android APK not found: ${ANDROID_APK}\n  Build it: cd app/android && ./gradlew assembleDebug`
+    );
+  }
+}
+
+/**
+ * Hardware attestation needs a secure lock screen (PIN/pattern/biometric) on
+ * the device — without one, Android's Keystore silently issues a non-attested
+ * key instead of failing loudly. That doesn't surface until the very end of
+ * this attended run, as a confusing "peer evidence missing" assertion failure
+ * on the OTHER phone. Catch it up front instead, in seconds, on both devices.
+ */
+function ensureLockScreenEnabled(udid) {
+  const disabled = execSync(`adb -s ${udid} shell locksettings get-disabled`).toString().trim();
+  if (disabled === "true") {
+    throw new Error(
+      `device ${udid} has no lock screen (PIN/pattern/biometric) set — hardware attestation requires ` +
+        `one on BOTH phones. Set a PIN/pattern/biometric on this device and retry.`
+    );
+  }
+}
+
+preflight();
+// Fail fast, before touching devices, if there's no mediator invitation to use.
+process.env.WITNESS_MEDIATOR_INVITATION_URL = resolveWitnessMediatorInvitationUrl();
+console.log(`[e2e] witness will run in MEDIATOR mode`);
+
+const { a: udidA, b: udidB } = detectTwoAndroidUdids();
+console.log(`[e2e] android devices: ${udidA}, ${udidB}`);
+ensureLockScreenEnabled(udidA);
+ensureLockScreenEnabled(udidB);
+for (const udid of [udidA, udidB]) {
+  try {
+    execSync(`adb -s ${udid} logcat -c`);
+  } catch {
+    /* non-fatal */
+  }
+}
+
+await runWitnessedExchange({
+  detectDevices: () => ({ a: udidA, b: udidB }),
+  createSessionA: (udid) => createSession("android", androidDeviceCaps(udid)),
+  createSessionB: (udid) => createSession("android", androidDeviceCaps(udid)),
+  dumpWitnessLogs: (udids) => dumpAndroidWitnessLogs(udids),
+  name: "vrc-exchange:witnessed:android-only:mediator",
+});

--- a/e2e/run-vrc-exchange-witnessed.js
+++ b/e2e/run-vrc-exchange-witnessed.js
@@ -23,7 +23,7 @@
 import { createSession, ensureAppium, stopAppium, screenshot, dumpSource } from "./lib/driver.js";
 import {
   acceptInvitationViaPaste,
-  acceptRelationshipProposalIfPrompted,
+  acceptRelationshipProposalOnEitherSide,
   assertContactShields,
   assertTrustTaskExchangeMarkers,
   assertWitnessCeremonyMarkers,
@@ -61,10 +61,7 @@ try {
   const invitationUrl = await showRelationshipInvitation(a);
   await acceptInvitationViaPaste(b, invitationUrl);
 
-  await Promise.all([
-    acceptRelationshipProposalIfPrompted(a),
-    acceptRelationshipProposalIfPrompted(b),
-  ]);
+  await acceptRelationshipProposalOnEitherSide(a, b);
 
   await Promise.all([
     assertVrcReceived(a, "Bob Baker"),

--- a/e2e/run-vrc-exchange.js
+++ b/e2e/run-vrc-exchange.js
@@ -21,7 +21,7 @@ import {
 } from "./lib/driver.js";
 import {
   acceptInvitationViaPaste,
-  acceptRelationshipProposalIfPrompted,
+  acceptRelationshipProposalOnEitherSide,
   assertTrustTaskExchangeMarkers,
   assertVrcReceived,
   completeOnboarding,
@@ -69,10 +69,7 @@ try {
   // v4 pairs: consent is the RELATIONSHIP PROPOSAL — one side gets the
   // "wants to form a relationship" prompt; on Accept both signed VRCs flow
   // automatically as trust tasks (no per-credential offers to accept).
-  await Promise.all([
-    acceptRelationshipProposalIfPrompted(a),
-    acceptRelationshipProposalIfPrompted(b),
-  ]);
+  await acceptRelationshipProposalOnEitherSide(a, b);
 
   await Promise.all([
     assertVrcReceived(a, "Bob Baker"),

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "e2e:smoke": "cd e2e && npm run onboarding-smoke",
     "e2e:vrc:witnessed": "cd e2e && npm run vrc-exchange:witnessed",
     "e2e:vrc:witnessed:devices": "cd e2e && npm run vrc-exchange:witnessed:devices",
-    "e2e:vrc:witnessed:android-only": "cd e2e && npm run vrc-exchange:witnessed:android-only"
+    "e2e:vrc:witnessed:android-only": "cd e2e && npm run vrc-exchange:witnessed:android-only",
+    "e2e:vrc:witnessed:android-only:mediator": "cd e2e && npm run vrc-exchange:witnessed:android-only:mediator"
   },
   "devDependencies": {
     "@commitlint/cli": "~19.8.1",


### PR DESCRIPTION
**Branch:** `fix/mediator-pickup-strategy` → `feat/trust-tasks-integration` (9 commits). Pairs with keyring-bifold PR berkmancenter/keyring-bifold#41 (same branch name), which carries the actual mediation fix and one follow-up fix; this branch bumps to pick both up and hardens the e2e harness around the failure this was diagnosing. Code-reviewed the full `main..HEAD` range (59 commits) first — findings below, all fixed here.

## What this is

- **`9c80583` / `9ee0dd1`** — real-device VRC e2e updated for android-to-android + v4 consent; wires in explicit message pickup (bifold bump) and the `bc-agent-modules.ts` Implicit→PickUpV2 change plus a stop-before-start guard in `useBCAgentSetup.ts`.
- **`28aec73` → `f2551df`** — hardens the witnessed e2e run against `.env` transport drift, closes out a fourth failure layer, and records a confirmable mediator-mode witness variant + the confirmation run. Spike docs under `docs/spikes/`.
- **`e668ace`** — records the fix in the plan companions.
- **`c9eb777` fix: narrow retry/resolver fallthrough and harden e2e proposal-accept** — four fixes from the full-branch review:
  - `RetryingHttpOutboundTransport` (`useBCAgentSetup.ts`) retried on *any* exception, not just the documented stale-socket case — risked silently resending an already-delivered, non-idempotent DIDComm message. Narrowed to the specific `cause.message === 'Network request failed'` symptom.
  - `metro.config.js`'s `@openvtc/trust-tasks/*` resolver silently fell through to Metro's default resolution when no `dist/<subPath>.js` matched, reproducing the exact "no match was resolved" failure it exists to avoid. Now throws with the full list of paths it checked.
  - `e2e/lib/flows.js`'s `openContactDetail` treated any visible `ContactMenu` as "already on this contact's chat" without checking the peer's name was on screen.
  - `acceptRelationshipProposalIfPrompted` was called on both exchange sides in five e2e runners with no check that either side actually saw the proposal — a failed discovery silently degraded into a generic "contact never appeared" timeout instead of a clear failure. Added `acceptRelationshipProposalOnEitherSide`, wired into all five call sites.
- **`02a4cf6`** — bumps `bifold` to `104deb51` (keyring-bifold#41), the R-Card trailing-overlay fix found in the bifold-side review.

## Testing

- Root `yarn typecheck`, `yarn lint` — pass.
- `node --check` on all edited e2e files.
- `packages/core` (bifold): 173 suites, 1576 passed.

## Review coverage

Full-branch review (`main..HEAD`, 59 commits, low effort) covered the mediator-pickup fix itself plus everything else on `feat/trust-tasks-integration` — no issues found there beyond the four above, all in this branch's own e2e/config code. Notes going to #20 as a review comment.