### PR TITLE
feat: require signed and DCO-signed-off commits

### DIFF
--- a/.github/workflows/commit-checks.yml
+++ b/.github/workflows/commit-checks.yml
@@ -1,0 +1,57 @@
+name: Commit Requirements
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dco-and-signature:
+    runs-on: ubuntu-22.04
+    name: DCO sign-off and commit signature
+    steps:
+      - name: Check every commit in this PR is signed off and cryptographically signed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          fail=0
+
+          commits=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits" --paginate --jq '.[] | @base64')
+
+          for row in $commits; do
+            data=$(echo "$row" | base64 -d)
+            sha=$(echo "$data" | jq -r '.sha')
+            author_login=$(echo "$data" | jq -r '.author.login // empty')
+            message=$(echo "$data" | jq -r '.commit.message')
+            verified=$(echo "$data" | jq -r '.commit.verification.verified')
+            reason=$(echo "$data" | jq -r '.commit.verification.reason')
+
+            # Dependabot can't add a DCO sign-off, but its commits are already
+            # GitHub-verified, so only the sign-off check is skipped for it.
+            if [ "$author_login" = "dependabot[bot]" ]; then
+              if [ "$verified" != "true" ]; then
+                echo "::error::Commit $sha (dependabot) is not cryptographically verified by GitHub (reason: $reason)"
+                fail=1
+              fi
+              continue
+            fi
+
+            if ! printf '%s\n' "$message" | grep -qE '^Signed-off-by: .+ <.+@.+>$'; then
+              echo "::error::Commit $sha is missing a Signed-off-by trailer"
+              fail=1
+            fi
+
+            if [ "$verified" != "true" ]; then
+              echo "::error::Commit $sha is not cryptographically verified by GitHub (reason: $reason). Configure commit signing: https://docs.github.com/en/authentication/managing-commit-signature-verification"
+              fail=1
+            fi
+          done
+
+          exit $fail

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
+sh scripts/check-commit-signing.sh
 yarn pre-commit-lint
 yarn typecheck

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ Note: emulators/simulators cannot do hardware attestation — the app silently f
 - Conventional commits enforced by commitlint: `feat|fix|docs|style|refactor|perf|test|chore|revert`, lower-case type.
 - Commits in the `bifold/` submodule require `Signed-off-by: Alberto L <aleon@law.harvard.edu>` as the **last line** of the message (commitlint rejects anything after it). Do not add agent co-author trailers to bifold commits.
 - For message-only rewrites in bifold, use `git commit-tree -S` (SSH signing) to keep commits Verified; fallback `git commit -S -F msg.txt` with `HUSKY=0`.
+- Every commit on `main` (both repos) must also be cryptographically signed and verified by GitHub — enforced by branch protection and by the `commit-checks` CI workflow. `.husky/pre-commit` (root) and `bifold/.githooks/pre-commit` only check that `commit.gpgsign` is enabled locally, since a hook can't see the signature itself (git signs after hooks run).
 
 ## Ongoing upgrade work
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,12 @@ Government employees, public and members of the private sector are encouraged to
 Pull requests will be evaluated by the repository guardians on a schedule and if deemed beneficial will be committed to the master.
 
 All contributors retain the original copyright to their stuff, but by contributing to this project, you grant a world-wide, royalty-free, perpetual, irrevocable, non-exclusive, transferable license to all users **under the terms of the license under which this project is distributed.**
+
+## Commit Requirements
+
+Every commit on `main` must:
+
+1. **Carry a DCO sign-off** — a `Signed-off-by:` trailer, added automatically with `git commit -s`. Enforced locally by the `commit-msg` hook (via commitlint) and, redundantly, by CI.
+2. **Be cryptographically signed** (GPG or SSH) and verified by GitHub. Branch protection on `main` rejects unsigned commits outright; CI double-checks every commit on a pull request. A git hook can't verify the signature itself, since git signs a commit *after* hooks run — the local `pre-commit` hook only checks that signing is configured (`commit.gpgsign true`).
+
+See GitHub's guide to [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification) if you haven't set this up. The `bifold/` submodule has the same requirements — see `bifold/CONTRIBUTING` for its one-time hook setup (`git config core.hooksPath .githooks`, run automatically by `yarn install` at the repo root).

--- a/scripts/check-commit-signing.sh
+++ b/scripts/check-commit-signing.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Verifies commit signing is configured before allowing a commit to be made.
+#
+# This can only check the precondition, not the resulting signature: git
+# signs a commit in `commit-tree`, which runs *after* every hook here, so by
+# the time any hook sees a commit it's too late to reject an unsigned one.
+# Actual signature enforcement lives server-side (GitHub branch protection)
+# and in CI (.github/workflows/commit-checks.yml), which check the commit
+# after it exists. This hook just gives fast local feedback.
+
+gpgsign=$(git config --get commit.gpgsign || true)
+if [ "$gpgsign" != "true" ]; then
+  echo "error: commit signing is not enabled." >&2
+  echo "       This repo requires cryptographically signed commits." >&2
+  echo "       Run: git config commit.gpgsign true" >&2
+  echo "       and configure an SSH or GPG signing key." >&2
+  exit 1
+fi
+
+format=$(git config --get gpg.format || true)
+format=${format:-openpgp}
+if [ "$format" = "ssh" ] && [ -z "$(git config --get user.signingkey || true)" ]; then
+  echo "error: gpg.format is 'ssh' but user.signingkey is not set." >&2
+  echo "       Run: git config user.signingkey <path-to-public-key>" >&2
+  exit 1
+fi

--- a/scripts/ensure-bifold-ready.js
+++ b/scripts/ensure-bifold-ready.js
@@ -99,10 +99,21 @@ function buildBifoldPackages() {
   }
 }
 
+function configureBifoldHooks() {
+  // bifold has its own git directory (it's a submodule), so core.hooksPath
+  // must be set here rather than inherited from the parent repo. .githooks
+  // enforces DCO sign-off and signed commits — see bifold/CONTRIBUTING.
+  exec('git config core.hooksPath .githooks', {
+    cwd: BIFOLD_DIR,
+    ignoreErrors: true,
+  });
+}
+
 function main() {
   try {
     log('Starting bifold preparation...');
     ensureSubmoduleInitialized();
+    configureBifoldHooks();
     buildBifoldPackages();
     log('Bifold preparation complete');
   } catch (error) {


### PR DESCRIPTION
## Summary
- `.husky/pre-commit` now also runs `scripts/check-commit-signing.sh`, which fails fast if `commit.gpgsign` isn't enabled locally. `.husky/commit-msg` already enforces `Signed-off-by:` via commitlint.
- Add `.github/workflows/commit-checks.yml`, a PR check that walks every commit in the pull request via the GitHub API and fails if any (non-Dependabot) commit is missing `Signed-off-by:` or isn't GitHub-verified as cryptographically signed. Dependabot commits are exempted from the sign-off check (it can't add one) but still must be verified-signed.
- `scripts/ensure-bifold-ready.js` now also wires up the bifold submodule's own hooks (`git config core.hooksPath .githooks`) on every root `yarn install`, once berkmancenter/keyring-bifold#42 lands.
- Document the requirement in `CONTRIBUTING.md` and `CLAUDE.md`.

Companion PR for the submodule: berkmancenter/keyring-bifold#42 (same approach: `.githooks/`, `commit-checks.yaml`, CONTRIBUTING).

A git hook can't itself verify a commit's signature — git signs the commit object in `commit-tree`, which runs after every hook fires — so the pre-commit hook only checks that signing is *configured*. The actual signature is verified server-side: by CI on every PR now, and (once in-flight PRs on `main` are clear) by branch protection requiring signed commits, which rejects an unsigned commit outright. That branch-protection change is **not** included here since flipping it live today would immediately block every currently-open PR on `main` (several of which predate this change) until each is rebased with signed + signed-off commits — see PR discussion for the exact command to run once the queue is clear.

## Test plan
- [x] `yarn test` (full suite, via pre-push hook) — passed
- [x] `yarn pre-commit-lint` / `yarn typecheck` (via pre-commit hook) — passed
- [x] Committed this change itself with the new pre-commit signing check active, signed and signed off
- [ ] CI run on this PR (commit-checks.yml) — will self-validate once opened