### PR TITLE
fix(e2e): restore the comment opener lost in #30's merge

### DIFF
--- a/e2e/lib/flows.js
+++ b/e2e/lib/flows.js
@@ -1239,6 +1239,8 @@ export async function assertContactPhotoReceived(driver, peerName, timeout = 600
     `${driver.e2ePlatform}: no photo (ContactAvatarImage) shown for "${peerName}" within ${timeout}ms`
   );
 }
+
+/**
  * `assertVrcReceived`'s text match isn't scoped to the Contacts list — the
  * moment the VRC lands, Chat.tsx auto-pushes the peer's chat screen (header
  * text: the peer's own name) on top of the Contacts tab with a "Relationship


### PR DESCRIPTION
## Summary

`e2e/lib/flows.js` has an orphaned JSDoc body — the closing brace of `assertContactPhotoReceived` is followed directly by ` * \`assertVrcReceived\`'s text match…` with no `/**` opener.

That is a hard `SyntaxError`, so **every e2e suite on main is currently unrunnable** — node refuses to load the module before any test starts:

```
SyntaxError: Unexpected token '*'
    at compileSourceTextModule (node:internal/modules/esm/utils:340:16)
```

## Cause

The conflict resolution in **#30**'s merge of main. Both sides of that hunk began mid-comment — that branch added `assertContactPhotoReceived`, main added `dismissVrcConfirmationOverlayIfPresent` — and keeping both consumed main's `/**` opener while keeping its body. Every function survived intact, which is why it read as correct in review.

## Why nothing caught it

**`e2e/` is deliberately outside the yarn workspaces.** `yarn lint`, `yarn typecheck` and `yarn test` never touch it, and neither does CI. Both jobs were green on #30 while the harness could not start at all.

Found by actually running `yarn e2e:smoke` against consolidated main.

## Fix

The two missing lines. Verified `node --check` passes on `flows.js` and on every other file under `e2e/`.

## Worth doing separately

A `node --check e2e/**/*.js` step would be a few seconds of CI and would have caught this at the source. Right now the e2e harness has **no automated verification of any kind** — it is only exercised when someone runs a suite by hand.