### PR TITLE
fix(e2e): match the photo cell on both of Android's system pickers

### DIFF
--- a/e2e/lib/flows.js
+++ b/e2e/lib/flows.js
@@ -142,15 +142,25 @@ export async function pickRCardPhoto(driver) {
   await sleep(2000);
 
   try {
-    // Android's system Photo Picker (com.google.android.providers.media.module)
-    // wraps each grid thumbnail in a clickable FrameLayout carrying a
-    // "Photo taken on ..." content-desc; the ImageView thumbnail inside it
-    // is NOT itself clickable, confirmed via a live uiautomator dump against
-    // this exact picker on 2026-09-04.
+    // Android ships two different system photo pickers and their view trees
+    // are INVERTED with respect to each other, so do not constrain on
+    // clickable() here:
+    //
+    //   com.google.android.providers.media.module (seen 2026-09-04) wraps each
+    //     grid thumbnail in a CLICKABLE FrameLayout that carries the
+    //     "Photo taken on ..." content-desc.
+    //   com.google.android.photopicker (seen 2026-09-11, API 36) puts the
+    //     content-desc on a NON-clickable View, whose clickable parent carries
+    //     no description at all.
+    //
+    // Matching on the description alone works for both: the described node and
+    // its clickable ancestor share identical bounds, so a tap on either lands
+    // on the same pixel and the picker receives it. Both confirmed via live
+    // uiautomator dumps.
     const photoCell =
       driver.e2ePlatform === "android"
         ? driver.$(
-            'android=new UiSelector().clickable(true).descriptionContains("Photo")'
+            'android=new UiSelector().descriptionContains("Photo taken on")'
           )
         : driver.$("-ios class chain:**/XCUIElementTypeCell[1]");
     await photoCell.waitForExist({ timeout: 8000 });


### PR DESCRIPTION
## Summary

Android ships **two different system photo pickers**, and their view trees are **inverted** with respect to each other:

| Picker | Where the `"Photo taken on …"` content-desc lives | Clickable? |
|---|---|---|
| `com.google.android.providers.media.module` (seen 2026-09-04) | on the wrapping FrameLayout | **yes** |
| `com.google.android.photopicker` (seen 2026-09-11, API 36) | on an inner View | **no** — its clickable parent has no description |

The selector required both conditions on a single node:

```js
android=new UiSelector().clickable(true).descriptionContains("Photo")
```

On the newer picker that can never match — the described node isn't clickable, and the clickable ancestor has no description.

## Why it was hard to see

`pickRCardPhoto` treats a miss as non-fatal by design: it logs `could not find a photo to select in the native picker`, backs out, and continues, because `RCardOnboarding` submits fine without a photo. The run then fails several steps later at `assertContactPhotoReceived` — a long way from the cause.

## Fix

Match on the description alone. The described node and its clickable ancestor share **identical bounds**, so a tap on either lands on the same pixel and the picker receives it — correct on both structures.

Both pickers are now recorded in the comment with the package names and the dates they were observed, so the next divergence gets diagnosed rather than re-discovered.

## Verified

On an API 36 emulator, against consolidated main: the warning is gone and onboarding completes with the photo attached.

Found while running Rung 7 (full simulator suite on consolidated main). `e2e:smoke`, `e2e:vrc`, `e2e:vrc:witnessed` and `e2e:credential-exchange-query` all pass; `e2e:vrc:photo` gets past the picker with this fix and then hits a separate, unrelated 60s propose-timeout issue that is being tracked on its own.