### PR TITLE
fix(e2e): the photo runner never accepted the relationship proposal

### DIFF
--- a/e2e/run-vrc-exchange-photo.js
+++ b/e2e/run-vrc-exchange-photo.js
@@ -33,8 +33,8 @@ import {
   dumpSource,
 } from "./lib/driver.js";
 import {
-  acceptCredentialOfferFromChat,
   acceptInvitationViaPaste,
+  acceptRelationshipProposalOnEitherSide,
   assertContactPhotoReceived,
   assertVrcReceived,
   completeOnboarding,
@@ -79,12 +79,10 @@ try {
   const invitationUrl = await showRelationshipInvitation(a);
   await acceptInvitationViaPaste(b, invitationUrl);
 
-  // Bidirectional VRC: each wallet issues to the other, so BOTH get a credential
-  // offer in the contact chat that must be accepted manually.
-  await Promise.all([
-    acceptCredentialOfferFromChat(a),
-    acceptCredentialOfferFromChat(b),
-  ]);
+  // v4 pairs: consent is the RELATIONSHIP PROPOSAL — one side gets the
+  // "wants to form a relationship" prompt; on Accept both signed VRCs flow
+  // automatically as trust tasks (no per-credential offers to accept).
+  await acceptRelationshipProposalOnEitherSide(a, b);
 
   await Promise.all([
     assertVrcReceived(a, "Bob Baker"),


### PR DESCRIPTION
## Summary

`run-vrc-exchange-photo.js` went straight from `acceptInvitationViaPaste` to `acceptCredentialOfferFromChat`, **skipping `acceptRelationshipProposalOnEitherSide` entirely.**

Every other two-wallet runner calls it, because on v4 pairs **the consent IS the relationship proposal** — one side gets the "wants to form a relationship" prompt, and on Accept both signed VRCs flow automatically as trust tasks. There are no per-credential offers to accept on that path, so the two `acceptCredentialOfferFromChat` calls were the pre-v4 flow.

```
run-vrc-exchange.js        →  acceptRelationshipProposalOnEitherSide(a, b)   ← present
run-vrc-exchange-photo.js  →  (missing)
```

## What it looked like

A run that could never pass. The propose was sent, nothing ever tapped Accept, and the app **correctly** abandoned the exchange after its 60s wall-clock timeout:

```
12:23:55  [TrustTasks:Ceremony] propose sent (exchange 7528cfe3…)
12:25:11  [VRC Flow] Timeout after 60s | Status: proposed
```

Both wallets then idle-locked while waiting on an exchange that could no longer advance. Worth stating explicitly: **that lock is the visible symptom and it points away from the real cause** — it cost me a couple of wrong hypotheses before the runner comparison made it obvious.

Not caught earlier because the suite had only ever been run `android-only`, never in the two-platform configuration.

## Fix

Replace the two offer-accepts with the single proposal-accept, matching `run-vrc-exchange.js` exactly. The two runners now have an identical exchange sequence.

## Verified

API 36 emulator + iOS 26.3 simulator, against consolidated main:

```
[e2e] ios: tapped testID=ProposalAccept
[e2e] ios: relationship proposal accepted
[e2e] ios: photo present for "Alice Anderson"
✅  E2E PASSED — vrc-exchange-photo
```

**This is the first time this suite has run on iOS at all** — which also exercises #30's iOS prerequisites (`NSPhotoLibraryUsageDescription` and the regenerated `Podfile.lock`) for the first time.

Found during Rung 7.