### PR TITLE
ci(e2e): parse-check the harness, and document worktree + emulator recovery

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3,7 +3,7 @@ name: Code Quality
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, edited]
 
 jobs:
   lint:
@@ -47,6 +47,27 @@ jobs:
       - name: Check types
         working-directory: app
         run: yarn typecheck
+
+      # e2e/ is a standalone npm package, deliberately outside the yarn
+      # workspaces, so none of the steps above touch it. A syntax error there
+      # reaches main through a fully green CI run and breaks every suite at
+      # import time -- which is exactly what happened in #33. This is the
+      # cheapest gate that would have caught it; it needs no install, since
+      # node --check parses without resolving imports.
+      - name: Parse-check the e2e harness
+        run: |
+          set -euo pipefail
+          fail=0
+          while IFS= read -r f; do
+            # --input-type=module, NOT a plain `node --check <file>`: e2e/ is
+            # "type": "module" and `node --check` parses a path as CommonJS,
+            # where a stray JSDoc body after a `}` is legal-looking enough to
+            # pass. Verified against the #33 defect: `node --check` exits 0 on
+            # it, this exits 1.
+            node --input-type=module --check < "$f" \
+              || { echo "::error file=$f::$f is not valid ES module JavaScript"; fail=1; }
+          done < <(find e2e -name '*.js' -not -path 'e2e/node_modules/*' -not -path 'e2e/artifacts/*')
+          exit $fail
 
   test:
     runs-on: ubuntu-22.04

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -82,6 +82,73 @@ found" deep into a run. The harness checks this itself before starting
 message if `:8081` belongs to another checkout; when that happens, stop that
 Metro and run `yarn start` from **this** worktree's `app/` before retrying.
 
+## Running from a second worktree
+
+A fresh `git worktree` does **not** carry the untracked files a run needs, and
+each one fails differently and late. All four, in order:
+
+```sh
+git submodule update --init --recursive          # or yarn install dies in ~90ms
+cp <primary>/app/.env app/.env                    # baked in at BUILD time
+cp <primary>/app/android/local.properties app/android/local.properties
+(cd e2e && npm install)                           # e2e is outside the workspaces
+```
+
+What each looks like when missing, because none of them says so plainly:
+
+| Missing | Symptom |
+| --- | --- |
+| submodule not initialised | `yarn install` fails in ~90ms: `@bifold/core@portal:…: Manifest not found` |
+| `app/.env` | app boots, onboards, then hangs at `configuring message pickup` and shows "Oops! Something went wrong" — no `MEDIATOR_URL` |
+| `local.properties` | `SDK location not found` from gradle |
+| `e2e/node_modules` | `ERR_MODULE_NOT_FOUND: webdriverio` |
+
+**`app/.env` is baked in at build time** by `react-native-config`. Copying it
+after building is not enough — rebuild both binaries, or the app runs with no
+mediator and every exchange suite fails downstream of onboarding.
+
+**Worktrees have no git hooks.** `lefthook` is not on `PATH` there, so the
+pre-commit lint/format and pre-push test never run. Run the gates by hand
+before pushing from a worktree.
+
+**Stale worktrees lie about what compiles.** A worktree left for a few days can
+report `@bifold/core` "has no exported member" for symbols plainly present in
+the source — its `bifold/packages/core/lib/typescript/` artifact predates them.
+`yarn install` at the root may be a no-op, since yarn does not notice submodule
+content changing. Fix: `(cd bifold && yarn install)` then
+`yarn workspace @bifold/core run build`. Do **not** run bifold's root
+`yarn build` (see the root `CLAUDE.md`).
+
+## Emulator recovery: `io.appium.settings` will not start
+
+Symptom, on any Android suite, before a single test step runs:
+
+```
+Cannot start the 'io.appium.settings' application …
+Error: Activity class {io.appium.settings/io.appium.settings.Settings} does not exist.
+```
+
+The APK installs fine and declares the activity, and it even appears in the
+package manager's resolver table — but `am start-activity`, `monkey` and
+`cmd package resolve-activity` all deny it exists. That is corrupted package
+state on the AVD, and it **survives a reboot**.
+
+```sh
+emulator -avd <AVD> -wipe-data -no-snapshot-load
+```
+
+Do not uninstall `io.appium.settings` hoping to force a clean reinstall — a
+working older copy is the only thing keeping such an AVD usable, and removing
+it makes the problem permanent until the wipe.
+
+If `emulator` refuses with *"Running multiple emulators with the same AVD"*,
+clear the stale lock: `rm -rf ~/.android/avd/<AVD>.avd/*.lock`.
+
+A corrupted global Appium install shows up as
+`npm error Cannot read properties of null (reading 'package')` from
+`appium driver update`. Repair with
+`npx appium driver uninstall uiautomator2 && npx appium driver install uiautomator2`.
+
 ## Build the app binaries first
 
 The tests install pre-built binaries; they don't build the app for you.


### PR DESCRIPTION
Two gaps that between them cost about a day of Rung 7.

## The parse gate

`e2e/` is a standalone npm package, deliberately outside the yarn workspaces, so `yarn lint`, `yarn typecheck` and `yarn test` never touch it — and neither does CI. A syntax error there reaches main through a **fully green run** and breaks every suite at import time. That is exactly what #33 was.

The gate is deliberately:

```sh
node --input-type=module --check < "$f"
```

and **not** a plain `node --check "$f"`. `e2e/` is `"type": "module"`, and passing a *path* makes node parse it as CommonJS — where the #33 defect (a JSDoc body left stranded after a closing brace) is legal-looking enough to pass.

I built a faithful reproduction of #33 and measured both:

| | against the #33 defect | against the 26 real files |
|---|---|---|
| `node --check <path>` | **exit 0** — misses it | pass |
| `node --input-type=module --check <` | **exit 1** — catches it | all 26 pass |

Worth stating plainly: my first version of this gate used `node --check` and **would not have caught the bug it was written for.**

## The `edited` trigger

Retargeting a PR's base branch fires `edited`, which was not in the types list — so a retargeted PR ran **no checks at all**. #26 merged that way on 2026-09-08; #27 and #31 each needed a close/reopen to force a run. Brendan's `commit-checks.yml` already includes `edited`; this brings `quality.yml` in line.

## README: running from a second worktree

Four untracked prerequisites, each failing differently and late, with a symptom table. The one that cost the most: **`app/.env` is baked in at build time** by `react-native-config`, so copying it after building is not enough — the app boots, onboards, then hangs at `configuring message pickup` and shows "Oops! Something went wrong".

Also documents that worktrees have no git hooks, and that a stale worktree will report `@bifold/core` "has no exported member" for symbols plainly present in the source.

## README: emulator recovery

`io.appium.settings` will not start — the APK installs, declares the activity and appears in the resolver table, yet `am start-activity`, `monkey` and `cmd package resolve-activity` all deny it exists. Survives a reboot; needs `-wipe-data`.

Includes the warning I wish I'd had: **do not uninstall the package hoping to force a clean reinstall.** A working older copy is the only thing keeping such an AVD usable, and removing it made the problem permanent until the wipe. Also covers the stale AVD lock and the corrupted global Appium install.